### PR TITLE
feat(engine): add smarter recommendation filters for anti-manipulation and anti-adverse selection

### DIFF
--- a/packages/engine/tests/test_prediction_loader_stability.py
+++ b/packages/engine/tests/test_prediction_loader_stability.py
@@ -1,0 +1,28 @@
+"""Tests for stability field loading in prediction_loader."""
+
+import pytest
+
+
+class TestStabilityFieldsLoading:
+    """Test that new stability fields are fetched from predictions."""
+
+    def test_get_best_prediction_includes_stability_fields(self):
+        """Query should select stability fields when available."""
+        # Verify the SQL query includes new columns
+        # We'll check by inspecting the query string
+        import src.prediction_loader as pl_module
+        source = open(pl_module.__file__).read()
+
+        # These columns should be in the SELECT statement
+        assert 'median_14d' in source or 'p.median_14d' in source, \
+            "Query should select median_14d"
+        assert 'price_vs_median_ratio' in source, \
+            "Query should select price_vs_median_ratio"
+        assert 'return_1h' in source, \
+            "Query should select return_1h"
+        assert 'return_4h' in source, \
+            "Query should select return_4h"
+        assert 'return_24h' in source, \
+            "Query should select return_24h"
+        assert 'volatility_24h' in source, \
+            "Query should select volatility_24h"

--- a/packages/engine/tests/test_smarter_recommendations_integration.py
+++ b/packages/engine/tests/test_smarter_recommendations_integration.py
@@ -1,0 +1,346 @@
+"""Integration tests for smarter recommendation engine filters."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+class TestSmarterRecommendationsIntegration:
+    """End-to-end tests for the new filtering logic."""
+
+    @pytest.fixture
+    def mock_predictions_df(self):
+        """Create test prediction data with mix of good and bad predictions."""
+        return pd.DataFrame({
+            'item_id': [1, 2, 3, 4, 5],
+            'item_name': [
+                'Good Item',           # Normal, should pass
+                'Manipulated Junk',    # High ratio, low volume, cheap
+                'Falling Knife',       # Good stability, bad momentum
+                'Torva platebody',     # Low volume but expensive, ok
+                'Recovering Item',     # Was falling, now stable
+            ],
+            'current_high': [5_000_000, 500_000, 3_000_000, 500_000_000, 2_000_000],
+            'current_low': [4_900_000, 480_000, 2_900_000, 495_000_000, 1_950_000],
+            'buy_price': [4_900_000, 480_000, 2_900_000, 495_000_000, 1_950_000],
+            'sell_price': [5_100_000, 520_000, 3_100_000, 510_000_000, 2_050_000],
+            'hour_offset': [4, 4, 4, 12, 4],
+            'offset_pct': [0.02, 0.02, 0.02, 0.015, 0.02],
+            'fill_probability': [0.5, 0.6, 0.55, 0.4, 0.5],
+            'expected_value': [0.01, 0.015, 0.012, 0.008, 0.01],
+            'confidence': ['medium'] * 5,
+            # Stability fields
+            'median_14d': [4_800_000, 400_000, 3_000_000, 480_000_000, 2_000_000],
+            'price_vs_median_ratio': [1.04, 1.25, 1.00, 1.04, 1.00],
+            'volume_24h': [15000, 300, 8000, 150, 5000],
+            # Momentum fields
+            'return_1h': [0.005, 0.01, -0.02, 0.002, 0.001],
+            'return_4h': [0.01, 0.02, -0.04, 0.005, -0.01],
+            'return_24h': [0.02, 0.05, -0.06, 0.01, -0.03],
+            'volatility_24h': [0.01, 0.02, 0.015, 0.008, 0.012],
+        })
+
+    @pytest.fixture
+    def mock_loader(self, mock_predictions_df):
+        """Create mock prediction loader with test data."""
+        loader = MagicMock()
+
+        # Return the test predictions
+        loader.get_best_prediction_per_item.return_value = mock_predictions_df.copy()
+
+        # Mock batch methods
+        loader.get_batch_buy_limits.return_value = {
+            1: 100, 2: 1000, 3: 50, 4: 2, 5: 100
+        }
+        loader.get_batch_volumes_24h.return_value = {
+            1: 15000, 2: 300, 3: 8000, 4: 150, 5: 5000
+        }
+        loader.get_batch_volumes_1h.return_value = {
+            1: 500, 2: 10, 3: 300, 4: 5, 5: 200
+        }
+        loader.get_batch_trends.return_value = {
+            1: 'Stable', 2: 'Rising', 3: 'Falling', 4: 'Stable', 5: 'Stable'
+        }
+        loader.get_prediction_age_seconds.return_value = 60.0
+
+        return loader
+
+    @pytest.fixture
+    def engine(self, mock_loader):
+        """Create RecommendationEngine with mock loader."""
+        from src.config import Config
+        from src.recommendation_engine import RecommendationEngine
+
+        # Create engine without invoking __init__ to bypass DB connection
+        engine = RecommendationEngine.__new__(RecommendationEngine)
+
+        # Set up required attributes
+        engine.config = Config()
+        engine.config.price_buffer_enabled = False  # Disable randomness in tests
+        engine.loader = mock_loader
+        engine.store = MagicMock()
+        engine.crowding_tracker = MagicMock()
+        engine.crowding_tracker.filter_crowded_items.side_effect = lambda x: x
+
+        return engine
+
+    def test_manipulated_item_rejected(self, engine):
+        """Manipulated junk item should be filtered out by stability filter."""
+        # The 'Manipulated Junk' item has:
+        # - Low value (500k)
+        # - High price_vs_median_ratio (1.25 = 25% above)
+        # - Low volume (300)
+        # This should trigger the stability filter
+
+        recommendations = engine.get_recommendations(
+            style='active',
+            capital=10_000_000,
+            risk='medium',
+            slots=3,
+            active_trades=[],
+            exclude_ids=set(),
+            exclude_item_ids=set(),
+            user_id='test',
+        )
+
+        item_names = [r['item'] for r in recommendations]
+        assert 'Manipulated Junk' not in item_names, \
+            "Manipulated item with high ratio + low volume should be filtered"
+
+    def test_falling_knife_rejected_for_active(self, engine):
+        """Falling knife should be rejected for active trading."""
+        # The 'Falling Knife' item has:
+        # - Good stability (ratio 1.0)
+        # - But bad momentum: -2% 1h, -4% 4h
+        # For active style, this should be rejected
+
+        recommendations = engine.get_recommendations(
+            style='active',
+            capital=10_000_000,
+            risk='medium',
+            slots=3,
+            active_trades=[],
+            exclude_ids=set(),
+            exclude_item_ids=set(),
+            user_id='test',
+        )
+
+        item_names = [r['item'] for r in recommendations]
+        assert 'Falling Knife' not in item_names, \
+            "Item with bad momentum should be filtered for active style"
+
+    def test_expensive_low_volume_allowed(self, engine, mock_loader, mock_predictions_df):
+        """Expensive items should pass even with low volume."""
+        # Torva platebody has:
+        # - High value (500M)
+        # - Low volume (150) - normal for expensive items
+        # - Stable ratio (1.04)
+        # Should pass both filters
+        #
+        # Note: With 495M buy price and max 30% single trade allocation (medium risk),
+        # user needs at least 1.65B capital to afford 1 item. We use 2B to be safe.
+        # Alternatively using high risk allows 50% allocation (needs 990M).
+
+        # Filter predictions to ONLY include Torva platebody for this test
+        # to ensure it's not filtered out by stability/trend checks
+        torva_df = mock_predictions_df[
+            mock_predictions_df['item_name'] == 'Torva platebody'
+        ].copy()
+        mock_loader.get_best_prediction_per_item.return_value = torva_df
+        mock_loader.get_batch_buy_limits.return_value = {4: 2}
+        mock_loader.get_batch_volumes_24h.return_value = {4: 150}
+        mock_loader.get_batch_volumes_1h.return_value = {4: 5}
+        mock_loader.get_batch_trends.return_value = {4: 'Stable'}
+
+        # Use high risk which allows 50% single trade allocation (495M needs 990M capital)
+        recommendations = engine.get_recommendations(
+            style='passive',
+            capital=1_000_000_000,  # 1B capital
+            risk='high',  # High risk allows 50% allocation per trade
+            slots=2,
+            active_trades=[],
+            exclude_ids=set(),
+            exclude_item_ids=set(),
+            user_id='test',
+        )
+
+        item_names = [r['item'] for r in recommendations]
+        assert 'Torva platebody' in item_names, \
+            "Expensive items should pass with low volume"
+
+    def test_good_item_passes_all_filters(self, engine, mock_loader, mock_predictions_df):
+        """Normal good items should pass all filters."""
+        # Filter to ONLY Good Item for this test
+        # Note: Good Item buy_price is 4.9M. With medium risk (30% max allocation),
+        # we need 4.9M / 0.30 = ~16.3M capital minimum to afford 1 item.
+        good_item_df = mock_predictions_df[
+            mock_predictions_df['item_name'] == 'Good Item'
+        ].copy()
+        mock_loader.get_best_prediction_per_item.return_value = good_item_df
+        mock_loader.get_batch_buy_limits.return_value = {1: 100}
+        mock_loader.get_batch_volumes_24h.return_value = {1: 15000}
+        mock_loader.get_batch_volumes_1h.return_value = {1: 500}
+        mock_loader.get_batch_trends.return_value = {1: 'Stable'}
+
+        # Use 20M capital so 30% allocation (6M) can afford 1 item at 4.9M
+        recommendations = engine.get_recommendations(
+            style='active',
+            capital=20_000_000,
+            risk='medium',
+            slots=3,
+            active_trades=[],
+            exclude_ids=set(),
+            exclude_item_ids=set(),
+            user_id='test',
+        )
+
+        item_names = [r['item'] for r in recommendations]
+        assert 'Good Item' in item_names, \
+            "Normal stable items should pass all filters"
+
+    def test_recovering_item_passes(self, engine, mock_loader, mock_predictions_df):
+        """Item that was falling but now stable should pass."""
+        # Recovering Item has:
+        # - return_24h: -0.03 (was falling)
+        # - return_1h: 0.001 (now stable)
+        # - return_4h: -0.01 (recovering)
+        # For active style, recent stability matters more
+
+        # Filter to include Recovering Item
+        filtered_df = mock_predictions_df[
+            mock_predictions_df['item_name'] == 'Recovering Item'
+        ].copy()
+        mock_loader.get_best_prediction_per_item.return_value = filtered_df
+
+        recommendations = engine.get_recommendations(
+            style='active',
+            capital=10_000_000,
+            risk='medium',
+            slots=3,
+            active_trades=[],
+            exclude_ids=set(),
+            exclude_item_ids=set(),
+            user_id='test',
+        )
+
+        item_names = [r['item'] for r in recommendations]
+        assert 'Recovering Item' in item_names, \
+            "Item recovering from dip should pass for active style"
+
+    def test_filter_order_stability_then_trend(self, engine, mock_loader, mock_predictions_df):
+        """Verify both filters are applied in sequence."""
+        # Start with all items
+        mock_loader.get_best_prediction_per_item.return_value = mock_predictions_df.copy()
+
+        recommendations = engine.get_recommendations(
+            style='active',
+            capital=10_000_000,
+            risk='medium',
+            slots=5,
+            active_trades=[],
+            exclude_ids=set(),
+            exclude_item_ids=set(),
+            user_id='test',
+        )
+
+        item_names = [r['item'] for r in recommendations]
+
+        # Manipulated Junk should be caught by stability filter
+        assert 'Manipulated Junk' not in item_names
+
+        # Falling Knife should be caught by trend filter
+        assert 'Falling Knife' not in item_names
+
+        # Good items should remain
+        assert 'Good Item' in item_names or 'Recovering Item' in item_names
+
+    def test_passive_style_more_lenient_on_trends(self, engine, mock_loader, mock_predictions_df):
+        """Passive style should allow items that active rejects."""
+        # Create a prediction that would fail active but pass passive
+        # Moderate 24h decline but not severe
+        # Note: passive mode has capital efficiency threshold, so we use
+        # 50M capital to ensure the trade is viable for passive trading
+        moderate_decline_df = pd.DataFrame({
+            'item_id': [10],
+            'item_name': ['Moderate Decline'],
+            'current_high': [5_000_000],
+            'current_low': [4_900_000],
+            'buy_price': [4_900_000],
+            'sell_price': [5_100_000],
+            'hour_offset': [24],  # Long horizon for passive
+            'offset_pct': [0.02],
+            'fill_probability': [0.5],
+            'expected_value': [0.01],
+            'confidence': ['medium'],
+            'price_vs_median_ratio': [1.02],
+            'volume_24h': [10000],
+            'return_1h': [-0.005],
+            'return_4h': [-0.015],
+            'return_24h': [-0.04],  # Moderate decline
+        })
+
+        mock_loader.get_best_prediction_per_item.return_value = moderate_decline_df
+        mock_loader.get_batch_buy_limits.return_value = {10: 100}
+        mock_loader.get_batch_volumes_24h.return_value = {10: 10000}
+        mock_loader.get_batch_volumes_1h.return_value = {10: 500}
+        mock_loader.get_batch_trends.return_value = {10: 'Falling'}
+
+        # Should pass for passive style (longer horizon, more lenient)
+        # Using 50M capital to meet passive mode's capital efficiency threshold
+        passive_recs = engine.get_recommendations(
+            style='passive',
+            capital=50_000_000,
+            risk='medium',
+            slots=3,
+            active_trades=[],
+            exclude_ids=set(),
+            exclude_item_ids=set(),
+            user_id='test',
+        )
+
+        passive_names = [r['item'] for r in passive_recs]
+        assert 'Moderate Decline' in passive_names, \
+            "Passive style should allow moderate declines"
+
+    def test_empty_after_both_filters(self, engine, mock_loader):
+        """All items filtered should return empty list gracefully."""
+        # Create only bad items
+        all_bad_df = pd.DataFrame({
+            'item_id': [1, 2],
+            'item_name': ['Manipulated', 'Crashing'],
+            'current_high': [100_000, 100_000],
+            'current_low': [95_000, 95_000],
+            'buy_price': [95_000, 95_000],
+            'sell_price': [105_000, 105_000],
+            'hour_offset': [4, 4],
+            'offset_pct': [0.02, 0.02],
+            'fill_probability': [0.5, 0.5],
+            'expected_value': [0.01, 0.01],
+            'confidence': ['medium', 'medium'],
+            'price_vs_median_ratio': [1.30, 1.05],  # First manipulated
+            'volume_24h': [200, 500],  # Low volumes
+            'return_1h': [0.01, -0.03],  # Second crashing
+            'return_4h': [0.02, -0.05],
+            'return_24h': [0.05, -0.08],
+        })
+
+        mock_loader.get_best_prediction_per_item.return_value = all_bad_df
+        mock_loader.get_batch_buy_limits.return_value = {1: 1000, 2: 1000}
+        mock_loader.get_batch_volumes_24h.return_value = {1: 200, 2: 500}
+        mock_loader.get_batch_volumes_1h.return_value = {1: 10, 2: 20}
+        mock_loader.get_batch_trends.return_value = {1: 'Rising', 2: 'Falling'}
+
+        recommendations = engine.get_recommendations(
+            style='active',
+            capital=10_000_000,
+            risk='medium',
+            slots=3,
+            active_trades=[],
+            exclude_ids=set(),
+            exclude_item_ids=set(),
+            user_id='test',
+        )
+
+        assert recommendations == [], \
+            "Should return empty list when all items filtered"

--- a/packages/engine/tests/test_stability_filter.py
+++ b/packages/engine/tests/test_stability_filter.py
@@ -1,0 +1,92 @@
+"""Tests for price stability filter (anti-manipulation)."""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+
+class TestPriceStabilityFilter:
+    """Test _apply_price_stability_filter method."""
+
+    @pytest.fixture
+    def engine(self):
+        """Create a RecommendationEngine with mocked dependencies."""
+        from src.recommendation_engine import RecommendationEngine
+
+        mock_loader = MagicMock()
+        engine = RecommendationEngine.__new__(RecommendationEngine)
+        engine.loader = mock_loader
+        engine.logger = MagicMock()
+        return engine
+
+    @pytest.fixture
+    def normal_predictions(self):
+        """Predictions with normal price/median ratios."""
+        return pd.DataFrame({
+            'item_id': [1, 2, 3],
+            'item_name': ['Normal Item', 'Torva platebody', 'Cheap Item'],
+            'current_high': [5_000_000, 500_000_000, 100_000],
+            'price_vs_median_ratio': [1.02, 1.08, 1.03],  # All within bounds
+            'volume_24h': [10000, 200, 50000],
+        })
+
+    @pytest.fixture
+    def manipulated_predictions(self):
+        """Predictions with suspicious price spikes."""
+        return pd.DataFrame({
+            'item_id': [1, 2, 3],
+            'item_name': ['Junk Item', 'Torva platebody', 'Mid Item'],
+            'current_high': [100_000, 500_000_000, 5_000_000],
+            # Junk item spiked 20% on low volume - manipulation
+            # Torva 15% up but low volume is normal for expensive items
+            # Mid item 15% up on low volume - suspicious
+            'price_vs_median_ratio': [1.20, 1.15, 1.15],
+            'volume_24h': [500, 150, 800],
+        })
+
+    def test_passes_normal_items(self, engine, normal_predictions):
+        """Normal items should all pass the filter."""
+        result = engine._apply_price_stability_filter(normal_predictions)
+        assert len(result) == 3
+
+    def test_rejects_cheap_manipulated_items(self, engine, manipulated_predictions):
+        """Cheap items with price spikes on low volume should be rejected."""
+        result = engine._apply_price_stability_filter(manipulated_predictions)
+        # Junk item (100k, +20%, 500 vol) should be rejected
+        assert 1 not in result['item_id'].values
+
+    def test_allows_expensive_items_with_low_volume(self, engine, manipulated_predictions):
+        """Expensive items (>100M) allowed even with low volume."""
+        result = engine._apply_price_stability_filter(manipulated_predictions)
+        # Torva (500M, +15%, 150 vol) should pass - expensive items have low volume
+        assert 2 in result['item_id'].values
+
+    def test_rejects_mid_tier_manipulation(self, engine, manipulated_predictions):
+        """Mid-tier items with spikes on low volume should be rejected."""
+        result = engine._apply_price_stability_filter(manipulated_predictions)
+        # Mid item (5M, +15%, 800 vol) should be rejected
+        assert 3 not in result['item_id'].values
+
+    def test_skips_filter_if_fields_missing(self, engine):
+        """Should pass through if stability fields not in predictions."""
+        predictions = pd.DataFrame({
+            'item_id': [1, 2],
+            'item_name': ['Item A', 'Item B'],
+            # No price_vs_median_ratio column
+        })
+        result = engine._apply_price_stability_filter(predictions)
+        assert len(result) == 2
+
+    def test_handles_none_values(self, engine):
+        """Should handle None/NaN values in stability fields."""
+        predictions = pd.DataFrame({
+            'item_id': [1, 2],
+            'item_name': ['Item A', 'Item B'],
+            'current_high': [1_000_000, 2_000_000],
+            'price_vs_median_ratio': [None, 1.05],
+            'volume_24h': [1000, 2000],
+        })
+        result = engine._apply_price_stability_filter(predictions)
+        # Item with None ratio should pass (can't evaluate)
+        assert 1 in result['item_id'].values

--- a/packages/engine/tests/test_trend_entry_filter.py
+++ b/packages/engine/tests/test_trend_entry_filter.py
@@ -1,0 +1,94 @@
+"""Tests for trend entry filter (anti-adverse selection)."""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+
+class TestTrendEntryFilter:
+    """Test _apply_trend_entry_filter method."""
+
+    @pytest.fixture
+    def engine(self):
+        """Create a RecommendationEngine with mocked dependencies."""
+        from src.recommendation_engine import RecommendationEngine
+
+        mock_loader = MagicMock()
+        engine = RecommendationEngine.__new__(RecommendationEngine)
+        engine.loader = mock_loader
+        engine.logger = MagicMock()
+        return engine
+
+    @pytest.fixture
+    def stable_predictions(self):
+        """Predictions with stable/rising prices."""
+        return pd.DataFrame({
+            'item_id': [1, 2, 3],
+            'item_name': ['Stable', 'Rising', 'Slight Dip'],
+            'hour_offset': [4, 4, 4],
+            'return_1h': [0.001, 0.02, -0.005],
+            'return_4h': [0.005, 0.03, -0.01],
+            'return_24h': [0.01, 0.05, -0.02],
+        })
+
+    @pytest.fixture
+    def falling_predictions(self):
+        """Predictions with falling prices."""
+        return pd.DataFrame({
+            'item_id': [1, 2, 3],
+            'item_name': ['Crashing', 'Falling Knife', 'Stable'],
+            'hour_offset': [4, 4, 4],
+            'return_1h': [-0.03, -0.02, 0.001],
+            'return_4h': [-0.05, -0.04, 0.005],
+            'return_24h': [-0.08, -0.06, 0.01],
+        })
+
+    def test_passes_stable_items_active_style(self, engine, stable_predictions):
+        """Stable/rising items should pass for active trading."""
+        result = engine._apply_trend_entry_filter(stable_predictions, style='active')
+        assert len(result) == 3
+
+    def test_rejects_crashing_items_active_style(self, engine, falling_predictions):
+        """Crashing items should be rejected for active trading."""
+        result = engine._apply_trend_entry_filter(falling_predictions, style='active')
+        assert 'Crashing' not in result['item_name'].values
+        assert 'Falling Knife' not in result['item_name'].values
+        assert 'Stable' in result['item_name'].values
+
+    def test_passive_style_more_lenient(self, engine, falling_predictions):
+        """Passive style should allow moderate dips."""
+        falling_predictions['hour_offset'] = 24
+        result = engine._apply_trend_entry_filter(falling_predictions, style='passive')
+        # Only Crashing should be rejected (>-8% 24h)
+        assert 'Crashing' not in result['item_name'].values
+
+    def test_hybrid_style_moderate(self, engine, falling_predictions):
+        """Hybrid style should have moderate thresholds."""
+        falling_predictions['hour_offset'] = 8
+        result = engine._apply_trend_entry_filter(falling_predictions, style='hybrid')
+        # Items with >4% 4h drop should be rejected
+        assert 'Crashing' not in result['item_name'].values
+
+    def test_skips_filter_if_fields_missing(self, engine):
+        """Should pass through if return fields not in predictions."""
+        predictions = pd.DataFrame({
+            'item_id': [1, 2],
+            'item_name': ['Item A', 'Item B'],
+            'hour_offset': [4, 4],
+        })
+        result = engine._apply_trend_entry_filter(predictions, style='active')
+        assert len(result) == 2
+
+    def test_handles_none_values(self, engine):
+        """Should handle None/NaN values in return fields."""
+        predictions = pd.DataFrame({
+            'item_id': [1, 2],
+            'item_name': ['Item A', 'Item B'],
+            'hour_offset': [4, 4],
+            'return_1h': [None, -0.01],
+            'return_4h': [None, -0.02],
+            'return_24h': [None, -0.03],
+        })
+        result = engine._apply_trend_entry_filter(predictions, style='active')
+        assert 1 in result['item_id'].values

--- a/packages/model/scripts/migrations/015_add_stability_fields.sql
+++ b/packages/model/scripts/migrations/015_add_stability_fields.sql
@@ -1,0 +1,27 @@
+-- Migration: Add price stability and momentum fields for smarter filtering
+-- Run: psql $DATABASE_URL -f packages/model/scripts/migrations/015_add_stability_fields.sql
+
+BEGIN;
+
+-- Add new columns to predictions table
+ALTER TABLE predictions ADD COLUMN IF NOT EXISTS median_14d DECIMAL(12,2);
+ALTER TABLE predictions ADD COLUMN IF NOT EXISTS price_vs_median_ratio DECIMAL(6,4);
+ALTER TABLE predictions ADD COLUMN IF NOT EXISTS return_1h DECIMAL(6,4);
+ALTER TABLE predictions ADD COLUMN IF NOT EXISTS return_4h DECIMAL(6,4);
+ALTER TABLE predictions ADD COLUMN IF NOT EXISTS return_24h DECIMAL(6,4);
+ALTER TABLE predictions ADD COLUMN IF NOT EXISTS volatility_24h DECIMAL(6,4);
+
+-- Add same columns to staging table if it exists
+ALTER TABLE IF EXISTS predictions_staging ADD COLUMN IF NOT EXISTS median_14d DECIMAL(12,2);
+ALTER TABLE IF EXISTS predictions_staging ADD COLUMN IF NOT EXISTS price_vs_median_ratio DECIMAL(6,4);
+ALTER TABLE IF EXISTS predictions_staging ADD COLUMN IF NOT EXISTS return_1h DECIMAL(6,4);
+ALTER TABLE IF EXISTS predictions_staging ADD COLUMN IF NOT EXISTS return_4h DECIMAL(6,4);
+ALTER TABLE IF EXISTS predictions_staging ADD COLUMN IF NOT EXISTS return_24h DECIMAL(6,4);
+ALTER TABLE IF EXISTS predictions_staging ADD COLUMN IF NOT EXISTS volatility_24h DECIMAL(6,4);
+
+-- Create index for filtering by price anomalies
+CREATE INDEX IF NOT EXISTS idx_predictions_stability
+ON predictions (time, price_vs_median_ratio, return_4h)
+WHERE price_vs_median_ratio IS NOT NULL;
+
+COMMIT;

--- a/packages/model/tests/test_stability_fields.py
+++ b/packages/model/tests/test_stability_fields.py
@@ -1,0 +1,214 @@
+"""Tests for price stability and momentum field computation."""
+
+import sys
+import os
+
+# Set dummy DB environment variables before importing modules that need them
+# These are only used to satisfy the module import; no actual DB connection is made in tests
+os.environ.setdefault('DB_PASS', 'test')
+os.environ.setdefault('DB_HOST', 'localhost')
+os.environ.setdefault('DB_PORT', '5432')
+os.environ.setdefault('DB_NAME', 'test')
+os.environ.setdefault('DB_USER', 'test')
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import numpy as np
+import pandas as pd
+import pytest
+from datetime import datetime, timedelta
+
+from batch_predictor_multitarget import compute_stability_fields
+
+
+@pytest.fixture
+def sample_price_history():
+    """Create 14 days of hourly price data."""
+    hours = 14 * 24  # 14 days
+    timestamps = [datetime.now() - timedelta(hours=i) for i in range(hours, 0, -1)]
+
+    # Stable item: prices hover around 1000 with small noise
+    np.random.seed(42)
+    base_price = 1000
+    noise = np.random.normal(0, 10, hours)  # ~1% noise
+    highs = base_price + noise + 5
+    lows = base_price + noise - 5
+
+    return pd.DataFrame({
+        'timestamp': timestamps,
+        'avg_high_price': highs,
+        'avg_low_price': lows,
+    }).set_index('timestamp').sort_index()
+
+
+@pytest.fixture
+def falling_price_history():
+    """Create price data with clear downtrend."""
+    hours = 14 * 24
+    timestamps = [datetime.now() - timedelta(hours=i) for i in range(hours, 0, -1)]
+
+    # Item falling 5% over last 4 hours
+    base_prices = np.linspace(1000, 950, hours)  # gradual decline
+    # Make last 4 hours steeper
+    base_prices[-4:] = np.linspace(970, 920, 4)
+
+    return pd.DataFrame({
+        'timestamp': timestamps,
+        'avg_high_price': base_prices + 5,
+        'avg_low_price': base_prices - 5,
+    }).set_index('timestamp')
+
+
+class TestComputeStabilityFields:
+    """Test stability field computation."""
+
+    def test_returns_all_required_fields(self, sample_price_history):
+        """Should return dict with all 6 required fields."""
+        result = compute_stability_fields(sample_price_history)
+
+        required_fields = [
+            'median_14d', 'price_vs_median_ratio',
+            'return_1h', 'return_4h', 'return_24h', 'volatility_24h'
+        ]
+        for field in required_fields:
+            assert field in result, f"Missing field: {field}"
+
+    def test_median_14d_is_reasonable(self, sample_price_history):
+        """Median should be close to the mean for stable prices."""
+        result = compute_stability_fields(sample_price_history)
+
+        # For our sample data centered around 1000
+        assert 950 < result['median_14d'] < 1050
+
+    def test_price_vs_median_ratio_near_one_for_stable(self, sample_price_history):
+        """Ratio should be ~1.0 for stable prices."""
+        result = compute_stability_fields(sample_price_history)
+
+        assert 0.95 < result['price_vs_median_ratio'] < 1.05
+
+    def test_return_4h_negative_for_falling(self, falling_price_history):
+        """4h return should be negative for falling prices."""
+        result = compute_stability_fields(falling_price_history)
+
+        assert result['return_4h'] < -0.02  # At least -2%
+
+    def test_return_1h_negative_for_falling(self, falling_price_history):
+        """1h return should be negative for active decline."""
+        result = compute_stability_fields(falling_price_history)
+
+        assert result['return_1h'] < 0
+
+    def test_volatility_24h_positive(self, sample_price_history):
+        """Volatility should always be positive."""
+        result = compute_stability_fields(sample_price_history)
+
+        assert result['volatility_24h'] > 0
+
+    def test_handles_missing_data_gracefully(self):
+        """Should return None values if insufficient history."""
+        # Only 2 hours of data
+        timestamps = [datetime.now() - timedelta(hours=i) for i in range(2, 0, -1)]
+        short_history = pd.DataFrame({
+            'timestamp': timestamps,
+            'avg_high_price': [100, 101],
+            'avg_low_price': [99, 100],
+        }).set_index('timestamp')
+
+        result = compute_stability_fields(short_history)
+
+        # Should still return dict, but some fields may be None
+        assert isinstance(result, dict)
+        # median_14d requires 14 days, so should be None
+        assert result['median_14d'] is None
+
+
+class TestStabilityFieldsEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_empty_dataframe_returns_none_fields(self):
+        """Empty input should return dict with all None values."""
+        empty_df = pd.DataFrame(columns=['avg_high_price', 'avg_low_price'])
+        result = compute_stability_fields(empty_df)
+
+        assert all(v is None for v in result.values())
+
+    def test_nan_prices_handled(self, sample_price_history):
+        """NaN prices should be handled without crashing."""
+        # Inject some NaNs
+        sample_price_history.iloc[10:15, 0] = np.nan
+
+        result = compute_stability_fields(sample_price_history)
+
+        # Should still compute (using available data)
+        assert result['median_14d'] is not None
+
+
+class TestInferenceIntegration:
+    """Test stability fields are included in predictions output."""
+
+    def test_stability_fields_added_to_predictions(self, sample_price_history):
+        """Stability fields should be computable and addable to predictions."""
+        # Compute stability fields (as would be done in run_inference_cycle)
+        stability = compute_stability_fields(sample_price_history)
+
+        # Create a sample prediction dict (as would be generated by predict_item)
+        prediction = {
+            'item_id': 1,
+            'item_name': 'Test Item',
+            'hour_offset': 4,
+            'offset_pct': 0.02,
+            'fill_probability': 0.5,
+            'expected_value': 0.01,
+            'buy_price': 100,
+            'sell_price': 104,
+            'current_high': 102,
+            'current_low': 98,
+            'confidence': 'medium',
+        }
+
+        # Add stability fields to prediction (as done in run_inference_cycle)
+        prediction['median_14d'] = stability.get('median_14d')
+        prediction['price_vs_median_ratio'] = stability.get('price_vs_median_ratio')
+        prediction['return_1h'] = stability.get('return_1h')
+        prediction['return_4h'] = stability.get('return_4h')
+        prediction['return_24h'] = stability.get('return_24h')
+        prediction['volatility_24h'] = stability.get('volatility_24h')
+
+        # Verify expected columns exist
+        expected_new_cols = [
+            'median_14d', 'price_vs_median_ratio',
+            'return_1h', 'return_4h', 'return_24h', 'volatility_24h'
+        ]
+        for col in expected_new_cols:
+            assert col in prediction, f"Missing field: {col}"
+
+        # Verify values are properly computed (not all None)
+        assert prediction['median_14d'] is not None
+        assert prediction['price_vs_median_ratio'] is not None
+        assert prediction['volatility_24h'] is not None
+
+    def test_stability_cache_pattern(self, sample_price_history, falling_price_history):
+        """Test the stability cache pattern used in run_inference_cycle."""
+        # Simulate price_data dict as used in run_inference_cycle
+        price_data = {
+            1: sample_price_history.reset_index(),
+            2: falling_price_history.reset_index()
+        }
+
+        # Build stability cache (as done in run_inference_cycle)
+        stability_cache = {}
+        for item_id, df in price_data.items():
+            # Need to set index back for compute_stability_fields
+            if 'timestamp' in df.columns:
+                df = df.set_index('timestamp')
+            stability_cache[item_id] = compute_stability_fields(df)
+
+        # Verify cache structure
+        assert 1 in stability_cache
+        assert 2 in stability_cache
+
+        # Stable item should have ratio close to 1
+        assert 0.95 < stability_cache[1]['price_vs_median_ratio'] < 1.05
+
+        # Falling item should have negative returns
+        assert stability_cache[2]['return_4h'] < 0

--- a/packages/shared/schemas/predictions.sql
+++ b/packages/shared/schemas/predictions.sql
@@ -21,6 +21,16 @@ CREATE TABLE IF NOT EXISTS predictions (
     current_high DECIMAL(12,2),
     current_low DECIMAL(12,2),
 
+    -- Price stability fields (for anti-manipulation filtering)
+    median_14d DECIMAL(12,2),              -- 14-day median price
+    price_vs_median_ratio DECIMAL(6,4),    -- current_mid / median_14d
+
+    -- Momentum fields (for anti-adverse-selection filtering)
+    return_1h DECIMAL(6,4),                -- 1-hour price return
+    return_4h DECIMAL(6,4),                -- 4-hour price return
+    return_24h DECIMAL(6,4),               -- 24-hour price return
+    volatility_24h DECIMAL(6,4),           -- 24-hour rolling volatility
+
     -- Metadata
     item_name TEXT,
     confidence TEXT,                         -- low | medium | high


### PR DESCRIPTION
## Summary

Two new entry filters to prevent money-losing recommendations:

**1. Price Stability Filter (anti-manipulation)**
- Detects items with abnormally high prices relative to 14-day median
- Value-tiered thresholds: expensive items (>100M) get relaxed limits
- Rejects cheap items with inflated prices and low volume

**2. Trend Entry Filter (anti-adverse selection)**
- Prevents entering positions during negative momentum
- Style-aware: active (strict), hybrid (moderate), passive (relaxed)
- Blocks falling knives while allowing legitimate dip opportunities

## Implementation

- **Model**: `compute_stability_fields()` calculates `median_14d`, `price_vs_median_ratio`, `return_1h/4h/24h`, `volatility_24h` during inference
- **Engine**: Two filter methods integrated into `get_recommendations()` flow
- **Refactor**: Removed trend penalty from exit risk (now handled at entry)

## Schema Changes

- 6 new columns in predictions table (migration 015)
- Graceful fallback if fields missing (backward compatible)

## Test Plan

- [x] 11 model tests for stability field computation
- [x] 6 tests for price stability filter
- [x] 6 tests for trend entry filter  
- [x] 8 integration tests for full filter pipeline
- [x] 622 total tests passing

## Deployment Steps

1. Run migration: `psql $DATABASE_URL -f packages/model/scripts/migrations/015_add_stability_fields.sql`
2. Deploy model package (predictions will start including new fields)
3. Deploy engine package (will use new fields, falls back gracefully if missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)