### PR TITLE
fix(web): add opportunities cache and remove capital bucketing

### DIFF
--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1,5 +1,5 @@
 import type { Recommendation, UserSettings, ItemSearchResult } from './types';
-import { cache, cacheKey, bucketCapital, TTL, KEY } from './cache';
+import { cache, cacheKey, TTL, KEY } from './cache';
 
 function getApiBase(): string {
   // Server-side: use process.env directly (Vercel injects at runtime)
@@ -205,14 +205,13 @@ export async function getRecommendationByItemId(
   userId: string,
   settings: UserSettings
 ): Promise<Recommendation | null> {
-  // Cache by item ID + settings bucket (not user-specific)
-  const capitalBucket = bucketCapital(settings.capital);
+  // Cache by item ID + exact capital (not user-specific)
   const key = cacheKey(
     KEY.ITEM_PRICE,
     itemId.toString(),
     settings.style,
     settings.risk,
-    capitalBucket
+    settings.capital.toString()
   );
 
   try {

--- a/packages/web/src/lib/cache.ts
+++ b/packages/web/src/lib/cache.ts
@@ -25,6 +25,7 @@ export const TTL = {
   ITEM_SEARCH: 300,        // 5 minutes - item names rarely change
   ITEM_METADATA: 3600,     // 1 hour - item IDs/names very stable
   RECOMMENDATIONS: 30,     // 30 seconds - personalized, short cache
+  OPPORTUNITIES: 45,       // 45 seconds - shared data, changes every 5 min
   USER_SETTINGS: 300,      // 5 minutes - user settings
 } as const;
 
@@ -34,6 +35,7 @@ export const KEY = {
   ITEM_SEARCH: 'search:',
   ITEM_META: 'meta:',
   RECS: 'recs:',
+  OPPS: 'opps:',
   USER: 'user:',
   SSE: 'sse:',
 } as const;
@@ -204,19 +206,6 @@ export const pubsub = {
  */
 export function cacheKey(...parts: (string | number)[]): string {
   return parts.join(':');
-}
-
-/**
- * Helper to bucket capital values for cache key generation
- * This allows caching recommendations by capital range instead of exact value
- */
-export function bucketCapital(capital: number): string {
-  if (capital < 1_000_000) return '0-1m';
-  if (capital < 10_000_000) return '1-10m';
-  if (capital < 50_000_000) return '10-50m';
-  if (capital < 100_000_000) return '50-100m';
-  if (capital < 500_000_000) return '100-500m';
-  return '500m+';
 }
 
 export default cache;

--- a/packages/web/src/pages/api/recommendations.ts
+++ b/packages/web/src/pages/api/recommendations.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { userRepo, activeTradesRepo } from '../../lib/repositories';
 import { getRecommendations } from '../../lib/api';
-import { cache, cacheKey, bucketCapital, TTL, KEY } from '../../lib/cache';
+import { cache, cacheKey, TTL, KEY } from '../../lib/cache';
 
 export const GET: APIRoute = async ({ locals, request }) => {
   // Use request.url to get params - Astro's url object can lose query params with ISR
@@ -73,9 +73,8 @@ export const GET: APIRoute = async ({ locals, request }) => {
     // Check if client requested fresh data (bypass cache)
     const skipCache = url.searchParams.get('fresh') === '1';
 
-    // Build cache key based on effective settings
-    const capitalBucket = bucketCapital(availableCapital);
-    const redisCacheKey = cacheKey(KEY.RECS, userId, capitalBucket, effectiveStyle, effectiveRisk, effectiveMargin);
+    // Build cache key based on effective settings (use exact capital for accuracy)
+    const redisCacheKey = cacheKey(KEY.RECS, userId, availableCapital.toString(), effectiveStyle, effectiveRisk, effectiveMargin);
 
     // Try Redis cache first (unless fresh=1 requested)
     let recommendations: Awaited<ReturnType<typeof getRecommendations>> | null = null;

--- a/packages/web/src/pages/api/settings.ts
+++ b/packages/web/src/pages/api/settings.ts
@@ -98,7 +98,7 @@ export const PUT: APIRoute = async ({ request, locals }) => {
       await userRepo.update(userId, updates);
 
       // Clear user's recommendation cache so they get fresh data with new settings
-      // Key format: recs::userId:bucket:style:risk:margin (double colon after prefix)
+      // Key format: recs:userId:capital:style:risk:margin
       cache.delPattern(`${KEY.RECS}:${userId}:*`).catch(() => {});
     }
 


### PR DESCRIPTION
## Summary

- **#29 (Performance)**: Added 45s Redis response cache to the opportunities endpoint. Data refreshes every 5min so most requests within a window now hit cache. Cache key includes all filter/pagination params to prevent stale cross-query results.
- **#41 (Accuracy)**: Removed `bucketCapital()` and replaced with exact capital in cache keys. Previously, users could receive cached recommendations computed for a different capital amount due to broad bucketing ranges.
- Fixed stale comment in `settings.ts` referencing old cache key format.

## Changes

- `packages/web/src/pages/api/opportunities.ts` — Redis cache lookup/write with 45s TTL
- `packages/web/src/lib/cache.ts` — Added `TTL.OPPORTUNITIES` + `KEY.OPPS`, removed `bucketCapital()`
- `packages/web/src/pages/api/recommendations.ts` — Use exact capital in cache key
- `packages/web/src/lib/api.ts` — Use exact capital in item-specific recommendation cache key
- `packages/web/src/pages/api/settings.ts` — Fix stale comment

## Test plan

- [ ] Verify opportunities endpoint caches responses (second identical request within 45s should be fast)
- [ ] Verify different opportunity filter combos get separate cache entries
- [ ] Verify recommendation cache keys use exact capital (no bucketing)
- [ ] Verify cache gracefully degrades when Redis is unavailable

Closes #29, #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)