### PR TITLE
feat: add configurable model selection for prediction serving

### DIFF
--- a/packages/engine/src/config.py
+++ b/packages/engine/src/config.py
@@ -198,6 +198,13 @@ class Config:
         default_factory=lambda: environ.get("RATE_LIMIT_OUTCOMES", "30/minute")
     )
 
+    # Model selection - filter predictions by model_id
+    # Set to a specific model_id (e.g., "patchtst_patchtst") to only serve that model's predictions
+    # Leave empty to serve predictions from any model (default, backwards compatible)
+    preferred_model_id: str = field(
+        default_factory=lambda: environ.get("PREFERRED_MODEL_ID", "")
+    )
+
     # Logging configuration
     # LOG_LEVEL: DEBUG, INFO, WARNING, ERROR (default: INFO)
     # LOG_FORMAT: json (for production), text (for local development)

--- a/packages/engine/src/recommendation_engine.py
+++ b/packages/engine/src/recommendation_engine.py
@@ -97,6 +97,7 @@ class RecommendationEngine:
         self.loader = PredictionLoader(
             db_connection_string,
             pool_size=self.config.db_pool_size,
+            preferred_model_id=self.config.preferred_model_id,
         )
         self.store = RecommendationStore(ttl_seconds=900)
 
@@ -841,6 +842,12 @@ class RecommendationEngine:
                 f"Validation filters removed {filtered_count} invalid candidates "
                 f"({initial_count} -> {len(df)})"
             )
+
+        # Ensure prices are integers (OSRS prices are whole GP)
+        # Some models (e.g. PatchTST) write fractional prices to the DB
+        for col in ['buy_price', 'sell_price', 'current_high', 'current_low']:
+            if col in df.columns:
+                df[col] = df[col].astype(int)
 
         return df
 


### PR DESCRIPTION
## Summary
- Adds `PREFERRED_MODEL_ID` env var to filter all prediction queries by `model_id`, allowing the engine to serve a specific model's predictions (e.g. PatchTST instead of CatBoost)
- Updates all 6 query methods in `PredictionLoader` to scope `MAX(time)` to the preferred model when configured
- Fixes `ResponseValidationError` caused by PatchTST's fractional prices by casting to `int` in the candidate validation layer

## Context
Both CatBoost and PatchTST crons run every 5 minutes on Ampere. CatBoost finishes ~44s after PatchTST, so `MAX(time)` always picked CatBoost. This change lets us explicitly choose which model to serve. Currently deployed with `PREFERRED_MODEL_ID=patchtst_patchtst`.

## Test plan
- [x] Deployed to Ampere and verified health endpoint shows PatchTST prediction timestamps (~:03 cycle)
- [x] Verified `/api/v1/recommendations` returns HTTP 200 with PatchTST predictions
- [x] Confirmed backwards compatibility: empty `PREFERRED_MODEL_ID` leaves all queries unchanged
- [ ] Monitor for any issues over next 24h; switch back by setting `PREFERRED_MODEL_ID=` and restarting

🤖 Generated with [Claude Code](https://claude.com/claude-code)