### PR TITLE
security: P0 hardening — fail closed, require API key, harden rate limiting

### DIFF
--- a/packages/engine/src/config.py
+++ b/packages/engine/src/config.py
@@ -276,6 +276,11 @@ class Config:
         errors = []
         if not self.db_connection_string:
             errors.append("DB_CONNECTION_STRING is required")
+        if not self.internal_api_key:
+            errors.append(
+                "INTERNAL_API_KEY is required. "
+                "Generate one: python -c \"import secrets; print(secrets.token_urlsafe(32))\""
+            )
         return errors
 
 

--- a/packages/web/src/lib/webhook.ts
+++ b/packages/web/src/lib/webhook.ts
@@ -51,6 +51,7 @@ export async function dispatchWebhook(
  */
 export function generateSignature(body: string, timestamp: string): string {
   if (!WEBHOOK_SECRET) {
+    console.error('WEBHOOK_SECRET not configured — cannot sign outbound webhooks');
     return '';
   }
   const payload = `${timestamp}.${body}`;
@@ -67,8 +68,8 @@ export function verifyWebhookSignature(
   signature: string
 ): boolean {
   if (!WEBHOOK_SECRET) {
-    console.warn('WEBHOOK_SECRET not configured, accepting all webhooks');
-    return true;
+    console.error('WEBHOOK_SECRET not configured — rejecting webhook (fail closed)');
+    return false;
   }
 
   // Check timestamp to prevent replay attacks


### PR DESCRIPTION
## Summary

Three P0 security fixes from code audit (issues #54, #55, #56):

- **Webhook auth fails closed** — `verifyWebhookSignature()` now rejects all webhooks when `WEBHOOK_SECRET` is missing, instead of accepting them. Prevents unauthenticated alert injection.
- **Engine API key required at startup** — `config.validate()` blocks engine boot if `INTERNAL_API_KEY` is unset. Health endpoints remain public.
- **X-Forwarded-For hardened** — Rate limiter only trusts the header from known proxy IPs (`127.0.0.1`, `::1`, `172.17.0.1`). Prevents rate limit bypass via spoofed headers.

## Files changed

| File | Change |
|------|--------|
| `packages/web/src/lib/webhook.ts` | `verifyWebhookSignature()` returns `false` instead of `true` when secret missing |
| `packages/engine/src/config.py` | `validate()` rejects missing `INTERNAL_API_KEY` |
| `packages/engine/src/api.py` | `verify_api_key` docstring updated; `get_rate_limit_key` only trusts `X-Forwarded-For` from trusted proxies |
| `packages/engine/tests/test_api.py` | Updated auth tests, added trusted/untrusted proxy tests, removed dead `client_no_auth` fixture |

## Pre-merge checklist

- [x] Engine tests pass (531 passed, 39 skipped)
- [ ] Verify Vercel production has `WEBHOOK_SECRET` set (or webhook ingestion will be rejected)
- [ ] Verify Ampere `/opt/recommendation-engine/.env` has `INTERNAL_API_KEY` set (or engine won't restart)

## Test plan

- [x] `pytest tests/ -x -q` — all 531 tests pass
- [x] New test: `test_validate_rejects_missing_api_key` — confirms startup validation catches missing key
- [x] New test: `test_get_rate_limit_key_x_forwarded_for_trusted_proxy` — forwarded header accepted from localhost
- [x] New test: `test_get_rate_limit_key_x_forwarded_for_untrusted` — forwarded header ignored from external IP
- [x] Updated: `test_config_internal_api_key_default_empty` — now also asserts `validate()` rejects it

Closes #54, closes #55, closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)