### PR TITLE
fix: P1 reliability — table name drift, credential fallback, reset URL

### DIFF
--- a/packages/engine/src/prediction_loader.py
+++ b/packages/engine/src/prediction_loader.py
@@ -889,19 +889,19 @@ class PredictionLoader:
             return None
 
     def get_item_volume_1h(self, item_id: int) -> Optional[int]:
-        """Get last hour of trade volume from 1-minute data.
+        """Get last hour of trade volume from 5-minute data.
 
         Args:
             item_id: OSRS item ID
 
         Returns:
-            Total 1h volume (sum of high_volume + low_volume) or 0 if no data
+            Total 1h volume (sum of high_price_volume + low_price_volume) or 0 if no data
         """
         query = text(
             """
-            SELECT COALESCE(SUM(high_volume), 0)
-                   + COALESCE(SUM(low_volume), 0) as total_volume
-            FROM prices_1m
+            SELECT COALESCE(SUM(high_price_volume), 0)
+                   + COALESCE(SUM(low_price_volume), 0) as total_volume
+            FROM price_data_5min
             WHERE item_id = :item_id
               AND timestamp >= NOW() - INTERVAL '1 hour'
         """
@@ -972,9 +972,9 @@ class PredictionLoader:
         query = text(
             """
             SELECT item_id,
-                   COALESCE(SUM(high_volume), 0)
-                   + COALESCE(SUM(low_volume), 0) as total_volume
-            FROM prices_1m
+                   COALESCE(SUM(high_price_volume), 0)
+                   + COALESCE(SUM(low_price_volume), 0) as total_volume
+            FROM price_data_5min
             WHERE item_id = ANY(:item_ids)
               AND timestamp >= NOW() - INTERVAL '1 hour'
             GROUP BY item_id
@@ -1531,7 +1531,7 @@ class PredictionLoader:
             item_id: OSRS item ID
 
         Returns:
-            Dictionary with keys: timestamp, high, low, high_volume, low_volume
+            Dictionary with keys: timestamp, high, low, high_time, low_time
             Returns None if no data found
         """
         query = text(
@@ -1540,9 +1540,9 @@ class PredictionLoader:
                 timestamp,
                 high,
                 low,
-                high_volume,
-                low_volume
-            FROM prices_1m
+                high_time,
+                low_time
+            FROM prices_latest_1m
             WHERE item_id = :item_id
             ORDER BY timestamp DESC
             LIMIT 1
@@ -1560,8 +1560,8 @@ class PredictionLoader:
                 "timestamp": result[0],
                 "high": result[1],
                 "low": result[2],
-                "high_volume": result[3],
-                "low_volume": result[4],
+                "high_time": result[3],
+                "low_time": result[4],
             }
 
         except Exception as e:

--- a/packages/engine/tests/test_api.py
+++ b/packages/engine/tests/test_api.py
@@ -913,8 +913,8 @@ class TestAPI:
             "timestamp": datetime(2026, 1, 9, 12, 15, 0, tzinfo=timezone.utc),
             "high": 2089,
             "low": 2015,
-            "high_volume": 1000,
-            "low_volume": 500,
+            "high_time": datetime(2026, 1, 9, 12, 14, 0, tzinfo=timezone.utc),
+            "low_time": datetime(2026, 1, 9, 12, 13, 0, tzinfo=timezone.utc),
         }
 
         response = test_client.get("/api/v1/recommendations/item/536/refresh")

--- a/packages/engine/tests/test_order_advisor.py
+++ b/packages/engine/tests/test_order_advisor.py
@@ -19,8 +19,8 @@ class TestOrderAdvisor:
             "timestamp": "2024-01-01T00:00:00Z",
             "high": 1_000_000,  # Instant sell price
             "low": 980_000,  # Instant buy price
-            "high_volume": 100,
-            "low_volume": 100,
+            "high_time": "2024-01-01T00:00:00Z",
+            "low_time": "2024-01-01T00:00:00Z",
         }
         # Default predictions DataFrame
         loader.get_predictions_for_item.return_value = pd.DataFrame(
@@ -74,8 +74,8 @@ class TestOrderAdvisor:
             "timestamp": "2024-01-01T00:00:00Z",
             "high": 1_000_000,
             "low": 985_000,  # User's price is close to market
-            "high_volume": 100,
-            "low_volume": 100,
+            "high_time": "2024-01-01T00:00:00Z",
+            "low_time": "2024-01-01T00:00:00Z",
         }
 
         result = advisor.evaluate_order(
@@ -98,8 +98,8 @@ class TestOrderAdvisor:
             "timestamp": "2024-01-01T00:00:00Z",
             "high": 1_000_000,
             "low": 950_000,  # Market dropped, user's buy is too high
-            "high_volume": 100,
-            "low_volume": 100,
+            "high_time": "2024-01-01T00:00:00Z",
+            "low_time": "2024-01-01T00:00:00Z",
         }
 
         result = advisor.evaluate_order(
@@ -122,8 +122,8 @@ class TestOrderAdvisor:
             "timestamp": "2024-01-01T00:00:00Z",
             "high": 1_000_000,
             "low": 900_000,  # User's buy is way below market
-            "high_volume": 100,
-            "low_volume": 100,
+            "high_time": "2024-01-01T00:00:00Z",
+            "low_time": "2024-01-01T00:00:00Z",
         }
         # Predictions show low fill probability
         mock_loader.get_predictions_for_item.return_value = pd.DataFrame(
@@ -213,8 +213,8 @@ class TestOrderAdvisor:
             "timestamp": "2024-01-01T00:00:00Z",
             "high": 1_000_000,
             "low": 980_000,
-            "high_volume": 100,
-            "low_volume": 100,
+            "high_time": "2024-01-01T00:00:00Z",
+            "low_time": "2024-01-01T00:00:00Z",
         }
         mock_loader.get_predictions_for_item.return_value = pd.DataFrame()
         advisor = OrderAdvisor(loader=mock_loader)
@@ -377,8 +377,8 @@ class TestOrderAdvisorDecisionLogic:
             "timestamp": "2024-01-01T00:00:00Z",
             "high": 1_000_000,
             "low": 980_000,
-            "high_volume": 100,
-            "low_volume": 100,
+            "high_time": "2024-01-01T00:00:00Z",
+            "low_time": "2024-01-01T00:00:00Z",
         }
         mock_loader.get_predictions_for_item.return_value = pd.DataFrame(
             {
@@ -414,8 +414,8 @@ class TestOrderAdvisorDecisionLogic:
             "timestamp": "2024-01-01T00:00:00Z",
             "high": 1_000_000,
             "low": 980_000,  # Current market
-            "high_volume": 100,
-            "low_volume": 100,
+            "high_time": "2024-01-01T00:00:00Z",
+            "low_time": "2024-01-01T00:00:00Z",
         }
         mock_loader.get_predictions_for_item.return_value = pd.DataFrame(
             {

--- a/packages/model/collectors/collect_latest_1m.py
+++ b/packages/model/collectors/collect_latest_1m.py
@@ -38,7 +38,7 @@ DB_HOST = os.getenv("DB_HOST", "host.docker.internal")
 DB_PORT = os.getenv("DB_PORT", "5432")
 DB_NAME = os.getenv("DB_NAME", "osrs_data")
 DB_USER = os.getenv("DB_USER", "osrs_user")
-DB_PASS = os.getenv("DB_PASS", "osrs_pass")
+DB_PASS = os.environ["DB_PASS"]  # Required — crash at startup if missing
 
 METRICS_PORT = int(os.getenv("METRICS_PORT", "9103"))
 COLLECTION_INTERVAL = int(os.getenv("COLLECTION_INTERVAL", "60"))  # 1 minute

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -32,12 +32,13 @@ export const auth = betterAuth({
     sendResetPassword: async ({ user, url }) => {
       // TODO: Integrate with email service (SendGrid, Resend, etc.)
 
-      // In development, we'll use a simple approach
-      // The URL will be available in the server logs
       if (process.env.NODE_ENV === 'development') {
         console.log('\n=== PASSWORD RESET LINK ===');
         console.log(url);
         console.log('===========================\n');
+      } else {
+        // Production: log that a reset was requested (without the token/URL)
+        console.warn(`[Auth] Password reset requested for ${user.email} but no email service configured`);
       }
     },
   },


### PR DESCRIPTION
## Summary
Three P1 reliability fixes from the code audit:

- **#16 Table name mismatch**: Engine queried non-existent `prices_1m` table — 1h volume queries now use `price_data_5min` (which has volume columns), and `get_latest_price` now uses `prices_latest_1m` with correct columns (`high_time`/`low_time` instead of `high_volume`/`low_volume`). These queries were silently failing and returning 0/None on every request.
- **#18 Hardcoded DB password**: `collect_latest_1m.py` had `os.getenv("DB_PASS", "osrs_pass")` — the only collector with a fallback default. Changed to `os.environ["DB_PASS"]` to crash at startup like the other 4 collectors.
- **#19 Password reset logging**: Production `sendResetPassword` handler silently did nothing. Added a `console.warn` when no email service is configured so operators know the feature is being used but emails aren't sent.

## Test plan
- [x] All 531 engine tests pass (0 failures, 39 skipped)
- [x] Test mocks updated to match new `get_latest_price` return schema
- [x] Verified no consumer accesses `high_volume`/`low_volume` from `get_latest_price` (only `high`/`low`)
- [x] Verified `price_data_5min` table has `high_price_volume`/`low_price_volume` columns (matches 24h volume queries that already work)

Closes #16, closes #18, closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)