### PR TITLE
fix: remove inline imports, inject config via constructor

### DIFF
--- a/packages/engine/src/recommendation_engine.py
+++ b/packages/engine/src/recommendation_engine.py
@@ -91,6 +91,7 @@ class RecommendationEngine:
             db_connection_string,
             pool_size=self.config.db_pool_size,
             preferred_model_id=self.config.preferred_model_id,
+            config=self.config,
         )
         self.store = RecommendationStore(ttl_seconds=900)
 


### PR DESCRIPTION
## Summary
- Move `Config` and `get_wiki_api_client` imports to module level in `prediction_loader.py` — no actual circular dependency existed, just unnecessary caution
- Accept `config` as a constructor parameter via dependency injection instead of creating new `Config()` instances inside methods
- `RecommendationEngine` now passes its config through to `PredictionLoader`

Closes #24

## Test plan
- [x] 536 engine tests pass
- [x] Verified no circular import by checking `config.py` and `wiki_api.py` have no reverse imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)