### PR TITLE
feat: persist prediction context through trade lifecycle

### DIFF
--- a/packages/web/migrations/002_add_prediction_context.sql
+++ b/packages/web/migrations/002_add_prediction_context.sql
@@ -1,0 +1,14 @@
+-- Add prediction context columns to active_trades and trade_history
+-- These fields capture model prediction data for future ML feedback loop
+-- Run: psql $DATABASE_URL -f migrations/002_add_prediction_context.sql
+
+-- Active trades: store prediction context when trade is created from recommendation
+ALTER TABLE active_trades ADD COLUMN IF NOT EXISTS confidence TEXT;
+ALTER TABLE active_trades ADD COLUMN IF NOT EXISTS fill_probability REAL;
+ALTER TABLE active_trades ADD COLUMN IF NOT EXISTS expected_profit BIGINT;
+
+-- Trade history: preserve prediction context when trade completes
+ALTER TABLE trade_history ADD COLUMN IF NOT EXISTS expected_profit BIGINT;
+ALTER TABLE trade_history ADD COLUMN IF NOT EXISTS confidence TEXT;
+ALTER TABLE trade_history ADD COLUMN IF NOT EXISTS fill_probability REAL;
+ALTER TABLE trade_history ADD COLUMN IF NOT EXISTS expected_hours REAL;

--- a/packages/web/src/components/FlipCarousel.tsx
+++ b/packages/web/src/components/FlipCarousel.tsx
@@ -71,7 +71,11 @@ export default function FlipCarousel(props: FlipCarouselProps) {
           sellPrice: rec.sellPrice,
           quantity: rec.quantity,
           recId: rec.id,
-          modelId: rec.modelId
+          modelId: rec.modelId,
+          expectedHours: rec.expectedHours,
+          confidence: rec.confidence,
+          fillProbability: rec.fillProbability,
+          expectedProfit: rec.expectedProfit
         })
       });
 

--- a/packages/web/src/components/opportunities/OpportunityBrowser.tsx
+++ b/packages/web/src/components/opportunities/OpportunityBrowser.tsx
@@ -115,7 +115,11 @@ export function OpportunityBrowser(props: OpportunityBrowserProps) {
           sellPrice: opp.sellPrice,
           quantity: opp.quantity,
           recId: opp.id,
-          expectedHours: opp.expectedHours
+          expectedHours: opp.expectedHours,
+          modelId: opp.modelId,
+          confidence: opp.confidence,
+          fillProbability: opp.fillProbability,
+          expectedProfit: opp.expectedProfit
         })
       });
 

--- a/packages/web/src/lib/db.ts
+++ b/packages/web/src/lib/db.ts
@@ -62,6 +62,9 @@ export interface ActiveTrade {
   actual_sell_price: number | null;
   expected_hours: number | null;
   suggested_sell_price: number | null;
+  confidence: string | null;
+  fill_probability: number | null;
+  expected_profit: number | null;
 }
 
 export interface TradeHistory {
@@ -77,6 +80,10 @@ export interface TradeHistory {
   rec_id: string | null;
   model_id: string | null;
   status: 'completed' | 'cancelled';
+  expected_profit?: number | null;
+  confidence?: string | null;
+  fill_probability?: number | null;
+  expected_hours?: number | null;
   created_at: Date;
 }
 

--- a/packages/web/src/lib/repositories.ts
+++ b/packages/web/src/lib/repositories.ts
@@ -185,8 +185,8 @@ export const activeTradesRepo = {
     const nextCheckIn = new Date(Date.now() + firstCheckInMs);
 
     await sql`
-      INSERT INTO active_trades (id, user_id, item_id, item_name, buy_price, sell_price, quantity, rec_id, model_id, phase, progress, next_check_in, expected_hours)
-      VALUES (${id}, ${trade.user_id}, ${trade.item_id}, ${trade.item_name}, ${trade.buy_price}, ${trade.sell_price}, ${trade.quantity}, ${trade.rec_id || null}, ${trade.model_id || null}, 'buying', 0, ${nextCheckIn.toISOString()}, ${expectedHours})
+      INSERT INTO active_trades (id, user_id, item_id, item_name, buy_price, sell_price, quantity, rec_id, model_id, phase, progress, next_check_in, expected_hours, confidence, fill_probability, expected_profit)
+      VALUES (${id}, ${trade.user_id}, ${trade.item_id}, ${trade.item_name}, ${trade.buy_price}, ${trade.sell_price}, ${trade.quantity}, ${trade.rec_id || null}, ${trade.model_id || null}, 'buying', 0, ${nextCheckIn.toISOString()}, ${expectedHours}, ${trade.confidence || null}, ${trade.fill_probability || null}, ${trade.expected_profit || null})
     `;
     return (await this.findById(id))!;
   },
@@ -343,8 +343,8 @@ export const tradeHistoryRepo = {
   async create(trade: Omit<TradeHistory, 'id' | 'created_at'>): Promise<TradeHistory> {
     const id = generateId();
     await sql`
-      INSERT INTO trade_history (id, user_id, item_id, item_name, buy_price, sell_price, quantity, profit, notes, rec_id, model_id, status)
-      VALUES (${id}, ${trade.user_id}, ${trade.item_id || null}, ${trade.item_name}, ${trade.buy_price || null}, ${trade.sell_price || null}, ${trade.quantity || null}, ${trade.profit}, ${trade.notes || null}, ${trade.rec_id || null}, ${trade.model_id || null}, ${trade.status || 'completed'})
+      INSERT INTO trade_history (id, user_id, item_id, item_name, buy_price, sell_price, quantity, profit, notes, rec_id, model_id, status, expected_profit, confidence, fill_probability, expected_hours)
+      VALUES (${id}, ${trade.user_id}, ${trade.item_id || null}, ${trade.item_name}, ${trade.buy_price || null}, ${trade.sell_price || null}, ${trade.quantity || null}, ${trade.profit}, ${trade.notes || null}, ${trade.rec_id || null}, ${trade.model_id || null}, ${trade.status || 'completed'}, ${trade.expected_profit || null}, ${trade.confidence || null}, ${trade.fill_probability || null}, ${trade.expected_hours || null})
     `;
     const result = await sql<TradeHistory>`SELECT * FROM trade_history WHERE id = ${id}`;
     return result[0];

--- a/packages/web/src/lib/trade-types.ts
+++ b/packages/web/src/lib/trade-types.ts
@@ -104,6 +104,7 @@ export interface Opportunity {
   trend?: string;
   whyChips: WhyChip[];
   category?: string;
+  modelId?: string;
 }
 
 /** Response from the opportunities endpoint */

--- a/packages/web/src/pages/api/opportunities.ts
+++ b/packages/web/src/pages/api/opportunities.ts
@@ -102,7 +102,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
           volume24h: item.volume_24h,
           trend: item.trend,
           whyChips: item.why_chips,
-          category: item.category
+          category: item.category,
+          modelId: item.model_id
         })),
         total: data.total,
         hasMore: data.has_more

--- a/packages/web/src/pages/api/trades/active.ts
+++ b/packages/web/src/pages/api/trades/active.ts
@@ -50,7 +50,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
     const userId = locals.user.id;
     const body = await request.json();
-    const { itemId, itemName, buyPrice, sellPrice, quantity, recId, modelId, expectedHours } = body;
+    const { itemId, itemName, buyPrice, sellPrice, quantity, recId, modelId, expectedHours, confidence, fillProbability, expectedProfit } = body;
 
     // Validate required fields
     if (!itemId || !itemName || !buyPrice || !sellPrice || !quantity) {
@@ -147,7 +147,11 @@ export const POST: APIRoute = async ({ request, locals }) => {
       quantity,
       rec_id: recId || null,
       model_id: modelId || null,
-      expected_hours: expectedHours || undefined
+      expected_hours: expectedHours || undefined,
+      suggested_sell_price: null,
+      confidence: confidence || null,
+      fill_probability: fillProbability || null,
+      expected_profit: expectedProfit || null
     });
 
     // Dispatch webhook to ML engine (fire-and-forget)

--- a/packages/web/src/pages/api/trades/active/[id]/advance.ts
+++ b/packages/web/src/pages/api/trades/active/[id]/advance.ts
@@ -56,7 +56,7 @@ export const POST: APIRoute = async ({ params, locals }) => {
       const actualSellPrice = trade.actual_sell_price || trade.sell_price;
       const profit = (actualSellPrice - actualBuyPrice) * trade.quantity;
 
-      // Create history record
+      // Create history record (preserve prediction context from active trade)
       await tradeHistoryRepo.create({
         user_id: trade.user_id,
         item_id: trade.item_id,
@@ -68,7 +68,11 @@ export const POST: APIRoute = async ({ params, locals }) => {
         rec_id: trade.rec_id,
         model_id: trade.model_id,
         status: 'completed',
-        notes: null
+        notes: null,
+        expected_profit: trade.expected_profit,
+        confidence: trade.confidence,
+        fill_probability: trade.fill_probability,
+        expected_hours: trade.expected_hours
       });
 
       // Delete active trade

--- a/packages/web/src/pages/api/trades/active/[id]/complete.ts
+++ b/packages/web/src/pages/api/trades/active/[id]/complete.ts
@@ -41,7 +41,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
     const body = await request.json();
     const { sellPrice, quantity, profit, notes } = body;
 
-    // Create history entry
+    // Create history entry (preserve prediction context from active trade)
     await tradeHistoryRepo.create({
       user_id: userId,
       item_id: trade.item_id,
@@ -53,7 +53,11 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
       notes: notes || null,
       rec_id: trade.rec_id,
       model_id: trade.model_id,
-      status: 'completed'
+      status: 'completed',
+      expected_profit: trade.expected_profit,
+      confidence: trade.confidence,
+      fill_probability: trade.fill_probability,
+      expected_hours: trade.expected_hours
     });
 
     // Report to ML API (non-blocking)

--- a/packages/web/src/pages/api/trades/report.ts
+++ b/packages/web/src/pages/api/trades/report.ts
@@ -16,7 +16,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
     const userId = locals.user.id;
     const body = await request.json();
-    const { itemId, itemName, buyPrice, sellPrice, quantity, profit, notes, recId, modelId } = body;
+    const { itemId, itemName, buyPrice, sellPrice, quantity, profit, notes, recId, modelId, expectedProfit, confidence, fillProbability, expectedHours } = body;
 
     // Validate required fields
     if (!itemName || profit === undefined) {
@@ -72,7 +72,11 @@ export const POST: APIRoute = async ({ request, locals }) => {
       notes: notes || null,
       rec_id: recId || null,
       model_id: modelId || null,
-      status: 'completed'
+      status: 'completed',
+      expected_profit: expectedProfit || null,
+      confidence: confidence || null,
+      fill_probability: fillProbability || null,
+      expected_hours: expectedHours || null
     });
 
     // Report to ML API (non-blocking) if we have all the data


### PR DESCRIPTION
## Summary
- Stores model prediction data (confidence, fill probability, expected profit, expected hours) on `active_trades` at creation and carries it through to `trade_history` on completion
- Adds `modelId` mapping from engine opportunities response (was missing)
- Migration already applied to Neon — new trades will start collecting this data immediately

## Test plan
- [ ] Create a trade from FlipCarousel and verify `confidence`, `fill_probability`, `expected_profit` are stored in `active_trades`
- [ ] Complete a trade and verify prediction context is preserved in `trade_history`
- [ ] Cancel a trade and verify it still creates history without prediction context (optional fields)
- [ ] Create a trade from OpportunityBrowser and verify `modelId` is now passed through

🤖 Generated with [Claude Code](https://claude.com/claude-code)