### PR TITLE
feat: UX improvements and sparkline price charts

### DIFF
--- a/packages/web/CLAUDE.md
+++ b/packages/web/CLAUDE.md
@@ -1,5 +1,56 @@
 # Claude Code Instructions for gept-gg
 
+## Workflow Orchestration
+
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately - don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy to keep main context window clean
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One task per subagent for focused execution
+
+### 3. Self-Improvement Loop
+- After ANY correction from the user: update 'tasks/lessons.md' with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes - don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests -> then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+## Task Management
+1. **Plan First**: Write plan to 'tasks/todo.md' with checkable items
+2. **Verify Plan**: Check in before starting implementation
+3. **Track Progress**: Mark items complete as you go
+4. **Explain Changes**: High-level summary at each step
+5. **Document Results**: Add review to 'tasks/todo.md'
+6. **Capture Lessons**: Update 'tasks/lessons.md' after corrections
+
+## Core Principles
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
+
+
 ## Project Overview
 GePT is a Grand Exchange flipping assistant for Old School RuneScape. This repo contains the Astro/SolidJS frontend web application.
 

--- a/packages/web/src/components/Sparkline.tsx
+++ b/packages/web/src/components/Sparkline.tsx
@@ -1,0 +1,142 @@
+// packages/web/src/components/Sparkline.tsx
+import { createMemo } from 'solid-js';
+
+interface SparklineProps {
+  prices: number[];
+  predictedPrice?: number;
+  width?: number;
+  height?: number;
+  class?: string;
+}
+
+export function Sparkline(props: SparklineProps) {
+  const width = () => props.width ?? 120;
+  const height = () => props.height ?? 32;
+  const padding = 2;
+
+  const gradientId = `spark-grad-${Math.random().toString(36).slice(2, 8)}`;
+
+  const points = createMemo(() => {
+    const prices = props.prices;
+    if (!prices || prices.length < 2) return null;
+
+    const allValues = [...prices];
+    if (props.predictedPrice != null) allValues.push(props.predictedPrice);
+
+    const min = Math.min(...allValues);
+    const max = Math.max(...allValues);
+    const range = max - min || 1;
+
+    const w = width();
+    const h = height();
+    const xStep = (w - padding * 2) / (prices.length - 1);
+
+    const pts = prices.map((price, i) => ({
+      x: padding + i * xStep,
+      y: padding + (1 - (price - min) / range) * (h - padding * 2),
+    }));
+
+    let predicted: { x: number; y: number } | null = null;
+    if (props.predictedPrice != null) {
+      predicted = {
+        x: w - padding,
+        y: padding + (1 - (props.predictedPrice - min) / range) * (h - padding * 2),
+      };
+    }
+
+    return { pts, predicted, min, max, range };
+  });
+
+  const polyline = createMemo(() => {
+    const p = points();
+    if (!p) return '';
+    return p.pts.map(pt => `${pt.x},${pt.y}`).join(' ');
+  });
+
+  const areaPath = createMemo(() => {
+    const p = points();
+    if (!p) return '';
+    const h = height();
+    const pts = p.pts;
+    const first = pts[0];
+    const last = pts[pts.length - 1];
+    const line = pts.map(pt => `L${pt.x},${pt.y}`).join(' ');
+    return `M${first.x},${h} ${line} L${last.x},${h} Z`;
+  });
+
+  return (
+    <>
+      <svg
+        class={`sparkline ${props.class ?? ''}`}
+        viewBox={`0 0 ${width()} ${height()}`}
+        width={width()}
+        height={height()}
+        preserveAspectRatio="none"
+      >
+        {points() && (
+          <>
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stop-color="var(--accent)" stop-opacity="0.25" />
+                <stop offset="100%" stop-color="var(--accent)" stop-opacity="0" />
+              </linearGradient>
+            </defs>
+
+            {/* Area fill */}
+            <path d={areaPath()} fill={`url(#${gradientId})`} />
+
+            {/* History line */}
+            <polyline
+              points={polyline()}
+              fill="none"
+              stroke="var(--accent)"
+              stroke-width="1.5"
+              stroke-linejoin="round"
+              stroke-linecap="round"
+            />
+
+            {/* Current price dot */}
+            {(() => {
+              const p = points()!;
+              const last = p.pts[p.pts.length - 1];
+              return (
+                <circle
+                  cx={last.x}
+                  cy={last.y}
+                  r="2.5"
+                  fill="var(--accent)"
+                />
+              );
+            })()}
+
+            {/* Predicted price dashed line */}
+            {points()!.predicted && (() => {
+              const p = points()!;
+              const last = p.pts[p.pts.length - 1];
+              const pred = p.predicted!;
+              return (
+                <line
+                  x1={last.x}
+                  y1={last.y}
+                  x2={pred.x}
+                  y2={pred.y}
+                  stroke="var(--text-muted)"
+                  stroke-width="1"
+                  stroke-dasharray="3,2"
+                  stroke-linecap="round"
+                />
+              );
+            })()}
+          </>
+        )}
+      </svg>
+
+      <style>{`
+        .sparkline {
+          display: block;
+          overflow: visible;
+        }
+      `}</style>
+    </>
+  );
+}

--- a/packages/web/src/components/opportunities/OpportunityBrowser.tsx
+++ b/packages/web/src/components/opportunities/OpportunityBrowser.tsx
@@ -238,15 +238,16 @@ export function OpportunityBrowser(props: OpportunityBrowserProps) {
           onClick={() => fetchOpportunities(true)}
           disabled={loadingMore()}
         >
-          {loadingMore() ? 'Loading...' : 'Load more opportunities'}
+          {loadingMore() ? 'Loading...' : `Load more (${total() - visibleOpportunities().length} remaining)`}
         </button>
       </Show>
 
       <style>{`
         .opportunity-browser {
-          max-width: 600px;
+          max-width: 720px;
           margin: 0 auto;
           padding: 1rem;
+          padding-bottom: 5rem;
         }
 
         .opportunity-browser-count {

--- a/packages/web/src/components/opportunities/OpportunityCard.tsx
+++ b/packages/web/src/components/opportunities/OpportunityCard.tsx
@@ -1,7 +1,9 @@
 // packages/web/src/components/opportunities/OpportunityCard.tsx
-import { Show, For } from 'solid-js';
+import { Show, For, createSignal, createResource } from 'solid-js';
 import type { Opportunity } from '../../lib/trade-types';
 import Tooltip from '../Tooltip';
+import { Sparkline } from '../Sparkline';
+import { fetchPriceHistory } from '../../lib/price-history';
 
 interface OpportunityCardProps {
   opportunity: Opportunity;
@@ -13,6 +15,7 @@ interface OpportunityCardProps {
 
 export function OpportunityCard(props: OpportunityCardProps) {
   const opp = () => props.opportunity;
+  const [priceHistory] = createResource(() => opp().itemId, fetchPriceHistory);
 
   const formatGold = (amount: number) => {
     if (amount >= 1_000_000) {
@@ -70,6 +73,17 @@ export function OpportunityCard(props: OpportunityCardProps) {
           })()}
         </Tooltip>
       </div>
+
+      <Show when={priceHistory()}>
+        <div class="opportunity-card-sparkline">
+          <Sparkline
+            prices={priceHistory()!}
+            predictedPrice={opp().sellPrice}
+            width={props.expanded ? 280 : 160}
+            height={props.expanded ? 40 : 28}
+          />
+        </div>
+      </Show>
 
       <Show when={props.expanded}>
         <div class="opportunity-card-details">
@@ -188,6 +202,10 @@ export function OpportunityCard(props: OpportunityCardProps) {
           padding: 0.0625rem 0.375rem;
           border-radius: var(--radius-sm);
           cursor: default;
+        }
+
+        .opportunity-card-sparkline {
+          margin-top: 0.5rem;
         }
 
         .opportunity-card-details {

--- a/packages/web/src/components/trades/TradeCard.tsx
+++ b/packages/web/src/components/trades/TradeCard.tsx
@@ -1,7 +1,10 @@
 // packages/web/src/components/trades/TradeCard.tsx
+import { createResource } from 'solid-js';
 import type { TradeViewModel } from '../../lib/trade-types';
 import type { UpdateRecommendation } from '../../lib/types';
 import Tooltip from '../Tooltip';
+import { Sparkline } from '../Sparkline';
+import { fetchPriceHistory } from '../../lib/price-history';
 
 interface TradeCardProps {
   trade: TradeViewModel;
@@ -12,6 +15,8 @@ interface TradeCardProps {
 }
 
 export function TradeCard(props: TradeCardProps) {
+  const [priceHistory] = createResource(() => props.trade.itemId, fetchPriceHistory);
+
   const formatGold = (amount: number) => {
     if (amount >= 1_000_000) {
       return (amount / 1_000_000).toFixed(1) + 'M';
@@ -53,6 +58,17 @@ export function TradeCard(props: TradeCardProps) {
           {props.trade.phase.toUpperCase()}
         </span>
       </div>
+
+      {priceHistory() && (
+        <div class="trade-card-sparkline">
+          <Sparkline
+            prices={priceHistory()!}
+            predictedPrice={props.trade.sellPrice}
+            width={160}
+            height={28}
+          />
+        </div>
+      )}
 
       <div class="trade-card-progress">
         <Tooltip text={`${props.trade.phase === 'buying' ? 'Buy' : 'Sell'} progress: ${Math.round(props.trade.progress)}%`} position="top">
@@ -134,6 +150,10 @@ export function TradeCard(props: TradeCardProps) {
         .phase-selling {
           background: var(--phase-sell-light);
           color: var(--phase-sell);
+        }
+
+        .trade-card-sparkline {
+          margin-bottom: 0.5rem;
         }
 
         .trade-card-progress {

--- a/packages/web/src/components/trades/TradeDetail.tsx
+++ b/packages/web/src/components/trades/TradeDetail.tsx
@@ -1,10 +1,12 @@
 // packages/web/src/components/trades/TradeDetail.tsx
-import { createSignal, Show } from 'solid-js';
+import { createSignal, createResource, Show } from 'solid-js';
 import type { TradeViewModel, Guidance } from '../../lib/trade-types';
 import type { UpdateRecommendation } from '../../lib/types';
 import { CheckInBar } from './CheckInBar';
 import { GuidancePrompt } from './GuidancePrompt';
 import { AlertBanner } from './AlertBanner';
+import { Sparkline } from '../Sparkline';
+import { fetchPriceHistory } from '../../lib/price-history';
 
 interface TradeDetailProps {
   trade: TradeViewModel;
@@ -19,6 +21,7 @@ interface TradeDetailProps {
 }
 
 export function TradeDetail(props: TradeDetailProps) {
+  const [priceHistory] = createResource(() => props.trade.itemId, fetchPriceHistory);
   const [loading, setLoading] = createSignal(false);
   const [guidance, setGuidance] = createSignal<Guidance | undefined>(undefined);
   const [pendingProgress, setPendingProgress] = createSignal<number | undefined>(undefined);
@@ -126,6 +129,17 @@ export function TradeDetail(props: TradeDetailProps) {
           </Show>
         </div>
       </div>
+
+      <Show when={priceHistory()}>
+        <div class="trade-detail-sparkline">
+          <Sparkline
+            prices={priceHistory()!}
+            predictedPrice={props.trade.sellPrice}
+            width={280}
+            height={48}
+          />
+        </div>
+      </Show>
 
       <div class="trade-detail-profit">
         Target profit: <strong>+{formatGold(props.trade.targetProfit)}</strong>
@@ -325,6 +339,10 @@ export function TradeDetail(props: TradeDetailProps) {
         .price-arrow {
           color: var(--text-muted);
           font-size: 1rem;
+        }
+
+        .trade-detail-sparkline {
+          margin: 0.5rem 0;
         }
 
         .trade-detail-profit {

--- a/packages/web/src/components/trades/TradeList.tsx
+++ b/packages/web/src/components/trades/TradeList.tsx
@@ -186,7 +186,13 @@ export function TradeList(props: TradeListProps) {
         when={trades().length > 0}
         fallback={
           <div class="trade-list-empty">
-            <p>No active trades.</p>
+            <svg class="trade-list-empty-icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path d="M8 36V16l8-8h16l8 8v20a4 4 0 0 1-4 4H12a4 4 0 0 1-4-4z" />
+              <polyline points="16 28 24 20 32 28" />
+              <line x1="24" y1="20" x2="24" y2="36" />
+            </svg>
+            <p class="trade-list-empty-title">No active trades</p>
+            <p class="trade-list-empty-subtitle">Browse opportunities and add your first trade to get started.</p>
             <button
               class="trade-list-cta"
               onClick={() => props.onNavigateToOpportunities()}
@@ -240,9 +246,10 @@ export function TradeList(props: TradeListProps) {
 
       <style>{`
         .trade-list {
-          max-width: 600px;
+          max-width: 720px;
           margin: 0 auto;
           padding: 1rem;
+          padding-bottom: 5rem;
         }
 
         .trade-list-header {
@@ -261,6 +268,26 @@ export function TradeList(props: TradeListProps) {
           text-align: center;
           padding: 3rem 1rem;
           color: var(--text-secondary);
+        }
+
+        .trade-list-empty-icon {
+          width: 48px;
+          height: 48px;
+          color: var(--text-muted);
+          margin-bottom: 0.75rem;
+        }
+
+        .trade-list-empty-title {
+          font-size: var(--font-size-lg);
+          font-weight: 600;
+          color: var(--text-primary);
+          margin: 0 0 0.25rem;
+        }
+
+        .trade-list-empty-subtitle {
+          font-size: var(--font-size-sm);
+          color: var(--text-secondary);
+          margin: 0;
         }
 
         .trade-list-cta {

--- a/packages/web/src/layouts/Layout.astro
+++ b/packages/web/src/layouts/Layout.astro
@@ -90,12 +90,12 @@ const fullTitle = `${title} | GePT`;
                 </svg>
               </button>
               -->
-              <a href="https://discord.gg/dUCqkMdRJP" target="_blank" rel="noopener noreferrer" class="nav-discord" aria-label="Join our Discord">
+              <a href="https://discord.gg/dUCqkMdRJP" target="_blank" rel="noopener noreferrer" class="nav-discord" aria-label="Join our Discord" title="Join Discord">
                 <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
                   <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/>
                 </svg>
               </a>
-              <button class="theme-toggle" aria-label="Toggle theme">
+              <button class="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
               <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <circle cx="12" cy="12" r="5"/>
                 <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
@@ -104,7 +104,7 @@ const fullTitle = `${title} | GePT`;
                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
               </svg>
             </button>
-              <a href="/account" class="nav-account" aria-label="Account">
+              <a href="/account" class="nav-account" aria-label="Account" title="Account">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <circle cx="12" cy="8" r="4"/>
                   <path d="M4 20c0-4 4-6 8-6s8 2 8 6"/>

--- a/packages/web/src/lib/price-history.ts
+++ b/packages/web/src/lib/price-history.ts
@@ -1,0 +1,19 @@
+// Shared price history fetcher with module-level cache
+
+const priceHistoryCache = new Map<number, number[]>();
+
+export async function fetchPriceHistory(itemId: number): Promise<number[] | null> {
+  if (priceHistoryCache.has(itemId)) return priceHistoryCache.get(itemId)!;
+  try {
+    const res = await fetch(`/api/items/price-history/${itemId}`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (data.success && data.data?.prices?.length) {
+      priceHistoryCache.set(itemId, data.data.prices);
+      return data.data.prices;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/web/src/pages/account.astro
+++ b/packages/web/src/pages/account.astro
@@ -6,6 +6,10 @@ const user = Astro.locals.user;
 
 <Layout title="Account">
   <div class="container page">
+    <nav class="page-back">
+      <a href="/">← Back to Dashboard</a>
+    </nav>
+
     <header class="page-header">
       <h1>Account</h1>
       <p class="text-secondary">Manage your profile and subscription</p>
@@ -152,6 +156,19 @@ const user = Astro.locals.user;
         </div>
       </section>
 
+      <!-- Session -->
+      <section class="account-section">
+        <div class="section-content">
+          <div class="danger-option">
+            <div class="option-info">
+              <h3>Sign Out</h3>
+              <p class="text-secondary">Sign out of your account on this device</p>
+            </div>
+            <button class="btn btn-secondary" id="sign-out-btn">Sign Out</button>
+          </div>
+        </div>
+      </section>
+
       <!-- Danger Zone -->
       <section class="account-section danger">
         <div class="section-header">
@@ -162,13 +179,6 @@ const user = Astro.locals.user;
           <h2>Danger Zone</h2>
         </div>
         <div class="section-content">
-          <div class="danger-option">
-            <div class="option-info">
-              <h3>Sign Out</h3>
-              <p class="text-secondary">Sign out of your account on this device</p>
-            </div>
-            <button class="btn btn-secondary" id="sign-out-btn">Sign Out</button>
-          </div>
           <div class="danger-option">
             <div class="option-info">
               <h3>Delete Account</h3>
@@ -335,6 +345,21 @@ const user = Astro.locals.user;
 </script>
 
 <style>
+  .page-back {
+    margin-bottom: var(--space-3);
+  }
+
+  .page-back a {
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  .page-back a:hover {
+    color: var(--accent);
+  }
+
   .page-header {
     text-align: center;
     margin-bottom: var(--space-5);

--- a/packages/web/src/pages/api/items/price-history/[itemId].ts
+++ b/packages/web/src/pages/api/items/price-history/[itemId].ts
@@ -1,0 +1,106 @@
+import type { APIRoute } from 'astro';
+import { cache, cacheKey, TTL, KEY } from '../../../../lib/cache';
+
+const PREDICTION_API = import.meta.env.PREDICTION_API;
+const API_KEY = import.meta.env.PREDICTION_API_KEY;
+
+interface PriceHistoryCache {
+  prices: number[];
+  trend: string;
+}
+
+export const GET: APIRoute = async ({ params, locals }) => {
+  const itemId = parseInt(params.itemId || '');
+
+  if (!itemId || isNaN(itemId)) {
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Invalid item ID'
+    }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  if (!locals.user) {
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Unauthorized'
+    }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  if (!PREDICTION_API) {
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Service misconfigured'
+    }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  try {
+    const redisCacheKey = cacheKey(KEY.ITEM_PRICE, 'history', itemId.toString());
+
+    // Try cache first
+    let data: PriceHistoryCache | null = null;
+    try {
+      data = await cache.get<PriceHistoryCache>(redisCacheKey);
+    } catch (err) {
+      console.warn('[PriceHistory] Cache read failed:', (err as Error)?.message);
+    }
+
+    if (!data) {
+      const engineRes = await fetch(
+        `${PREDICTION_API}/api/v1/items/${itemId}/price-history?hours=24`,
+        {
+          headers: {
+            ...(API_KEY ? { 'X-API-Key': API_KEY } : {})
+          }
+        }
+      );
+
+      if (!engineRes.ok) {
+        throw new Error(`Engine returned ${engineRes.status}`);
+      }
+
+      const raw = await engineRes.json();
+
+      // Simplify extended price points to midpoint array for sparklines
+      const prices: number[] = (raw.history ?? []).map(
+        (pt: { high: number; low: number }) => Math.round((pt.high + pt.low) / 2)
+      );
+
+      data = {
+        prices,
+        trend: raw.trend ?? 'Stable',
+      };
+
+      // Cache for 5 minutes (prices update every ~5 min)
+      cache.set(redisCacheKey, data, TTL.ITEM_SEARCH).catch((err) => {
+        console.warn('[PriceHistory] Cache write failed:', err?.message);
+      });
+    }
+
+    return new Response(JSON.stringify({
+      success: true,
+      data
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+
+  } catch (error) {
+    console.error(`[PriceHistory/${itemId}] API Error:`, error);
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Failed to fetch price history'
+    }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- **Issue #77**: Navigation and layout UX improvements — tooltips on header icons, back navigation on account page, sign out separated from danger zone, wider content area (600→720px), load-more count, mobile feedback button overlap fix, improved empty state for zero trades
- **Issue #73**: Inline SVG sparkline price charts on opportunity and trade cards — custom `Sparkline` component with gradient fill, current price dot, and dashed predicted price line; price-history proxy API with Redis caching; integrated into OpportunityCard, TradeCard, and TradeDetail with graceful degradation

## Test plan
- [ ] Verify header icon tooltips appear on hover (Discord, theme toggle, account)
- [ ] Verify account page shows "← Back to Dashboard" link and Sign Out is outside Danger Zone
- [ ] Verify content area is wider on desktop (~720px)
- [ ] Verify load-more button shows remaining count
- [ ] Verify feedback button doesn't overlap last card on mobile
- [ ] Verify empty trades state shows icon, title, and subtitle
- [ ] Verify sparklines render on opportunity and trade cards (both collapsed and expanded)
- [ ] Verify sparklines show dashed predicted price line
- [ ] Verify sparklines degrade gracefully when price history is unavailable
- [ ] Verify light and dark mode rendering
- [ ] Verify mobile responsive at 390px viewport

Closes #77, closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)