### PR TITLE
fix: sparklines not rendering on most opportunity cards

### DIFF
--- a/packages/web/src/components/opportunities/OpportunityCard.tsx
+++ b/packages/web/src/components/opportunities/OpportunityCard.tsx
@@ -1,5 +1,5 @@
 // packages/web/src/components/opportunities/OpportunityCard.tsx
-import { Show, For, createSignal, createResource } from 'solid-js';
+import { Show, For, createSignal, onMount } from 'solid-js';
 import type { Opportunity } from '../../lib/trade-types';
 import Tooltip from '../Tooltip';
 import { Sparkline } from '../Sparkline';
@@ -15,7 +15,13 @@ interface OpportunityCardProps {
 
 export function OpportunityCard(props: OpportunityCardProps) {
   const opp = () => props.opportunity;
-  const [priceHistory] = createResource(() => opp().itemId, fetchPriceHistory);
+  const [priceHistory, setPriceHistory] = createSignal<number[] | null>(null);
+
+  onMount(() => {
+    fetchPriceHistory(opp().itemId).then(prices => {
+      if (prices) setPriceHistory(prices);
+    });
+  });
 
   const formatGold = (amount: number) => {
     if (amount >= 1_000_000) {

--- a/packages/web/src/components/trades/TradeCard.tsx
+++ b/packages/web/src/components/trades/TradeCard.tsx
@@ -1,5 +1,5 @@
 // packages/web/src/components/trades/TradeCard.tsx
-import { createResource } from 'solid-js';
+import { createSignal, onMount } from 'solid-js';
 import type { TradeViewModel } from '../../lib/trade-types';
 import type { UpdateRecommendation } from '../../lib/types';
 import Tooltip from '../Tooltip';
@@ -15,7 +15,13 @@ interface TradeCardProps {
 }
 
 export function TradeCard(props: TradeCardProps) {
-  const [priceHistory] = createResource(() => props.trade.itemId, fetchPriceHistory);
+  const [priceHistory, setPriceHistory] = createSignal<number[] | null>(null);
+
+  onMount(() => {
+    fetchPriceHistory(props.trade.itemId).then(prices => {
+      if (prices) setPriceHistory(prices);
+    });
+  });
 
   const formatGold = (amount: number) => {
     if (amount >= 1_000_000) {

--- a/packages/web/src/components/trades/TradeDetail.tsx
+++ b/packages/web/src/components/trades/TradeDetail.tsx
@@ -1,5 +1,5 @@
 // packages/web/src/components/trades/TradeDetail.tsx
-import { createSignal, createResource, Show } from 'solid-js';
+import { createSignal, onMount, Show } from 'solid-js';
 import type { TradeViewModel, Guidance } from '../../lib/trade-types';
 import type { UpdateRecommendation } from '../../lib/types';
 import { CheckInBar } from './CheckInBar';
@@ -21,7 +21,13 @@ interface TradeDetailProps {
 }
 
 export function TradeDetail(props: TradeDetailProps) {
-  const [priceHistory] = createResource(() => props.trade.itemId, fetchPriceHistory);
+  const [priceHistory, setPriceHistory] = createSignal<number[] | null>(null);
+
+  onMount(() => {
+    fetchPriceHistory(props.trade.itemId).then(prices => {
+      if (prices) setPriceHistory(prices);
+    });
+  });
   const [loading, setLoading] = createSignal(false);
   const [guidance, setGuidance] = createSignal<Guidance | undefined>(undefined);
   const [pendingProgress, setPendingProgress] = createSignal<number | undefined>(undefined);

--- a/packages/web/src/lib/cache.ts
+++ b/packages/web/src/lib/cache.ts
@@ -27,6 +27,7 @@ export const TTL = {
   RECOMMENDATIONS: 30,     // 30 seconds - personalized, short cache
   OPPORTUNITIES: 45,       // 45 seconds - shared data, changes every 5 min
   USER_SETTINGS: 300,      // 5 minutes - user settings
+  PRICE_HISTORY: 300,      // 5 minutes - sparkline price charts
 } as const;
 
 // Key prefixes for organization

--- a/packages/web/src/pages/api/items/price-history/[itemId].ts
+++ b/packages/web/src/pages/api/items/price-history/[itemId].ts
@@ -80,7 +80,7 @@ export const GET: APIRoute = async ({ params, locals }) => {
       };
 
       // Cache for 5 minutes (prices update every ~5 min)
-      cache.set(redisCacheKey, data, TTL.ITEM_SEARCH).catch((err) => {
+      cache.set(redisCacheKey, data, TTL.PRICE_HISTORY).catch((err) => {
         console.warn('[PriceHistory] Cache write failed:', err?.message);
       });
     }


### PR DESCRIPTION
## Summary
- Replace SolidJS `createResource` with `createSignal` + `onMount` for price history fetching in OpportunityCard, TradeCard, and TradeDetail
- Only 3 of 29 cards were rendering sparklines due to `createResource` not reliably updating reactive state when many concurrent fetch promises resolve simultaneously
- Add `PRICE_HISTORY` TTL constant to cache config (was using `ITEM_SEARCH` as a stand-in)

## Test plan
- [ ] Verify all opportunity cards show sparklines after page load
- [ ] Verify trade cards show sparklines
- [ ] Verify trade detail view shows larger sparkline
- [ ] Check both light and dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)