### PR TITLE
feat: sparkline spread band and colored prediction markers

### DIFF
--- a/packages/web/src/components/Sparkline.tsx
+++ b/packages/web/src/components/Sparkline.tsx
@@ -2,7 +2,8 @@
 import { createMemo } from 'solid-js';
 
 interface SparklineProps {
-  prices: number[];
+  highs: number[];
+  lows: number[];
   predictedPrice?: number;
   width?: number;
   height?: number;
@@ -15,12 +16,19 @@ export function Sparkline(props: SparklineProps) {
   const padding = 2;
 
   const gradientId = `spark-grad-${Math.random().toString(36).slice(2, 8)}`;
+  const spreadGradientId = `spark-spread-${Math.random().toString(36).slice(2, 8)}`;
 
   const points = createMemo(() => {
-    const prices = props.prices;
-    if (!prices || prices.length < 2) return null;
+    const highs = props.highs;
+    const lows = props.lows;
+    const len = Math.min(highs?.length ?? 0, lows?.length ?? 0);
+    if (len < 2) return null;
 
-    const allValues = [...prices];
+    // Compute midpoints
+    const mids = Array.from({ length: len }, (_, i) => (highs[i] + lows[i]) / 2);
+
+    // Global min/max includes spread and prediction
+    const allValues = [...highs.slice(0, len), ...lows.slice(0, len)];
     if (props.predictedPrice != null) allValues.push(props.predictedPrice);
 
     const min = Math.min(...allValues);
@@ -29,35 +37,50 @@ export function Sparkline(props: SparklineProps) {
 
     const w = width();
     const h = height();
-    const xStep = (w - padding * 2) / (prices.length - 1);
+    const xStep = (w - padding * 2) / (len - 1);
 
-    const pts = prices.map((price, i) => ({
-      x: padding + i * xStep,
-      y: padding + (1 - (price - min) / range) * (h - padding * 2),
-    }));
+    const toY = (val: number) => padding + (1 - (val - min) / range) * (h - padding * 2);
+
+    const highPts = highs.slice(0, len).map((v, i) => ({ x: padding + i * xStep, y: toY(v) }));
+    const lowPts = lows.slice(0, len).map((v, i) => ({ x: padding + i * xStep, y: toY(v) }));
+    const midPts = mids.map((v, i) => ({ x: padding + i * xStep, y: toY(v) }));
 
     let predicted: { x: number; y: number } | null = null;
     if (props.predictedPrice != null) {
       predicted = {
         x: w - padding,
-        y: padding + (1 - (props.predictedPrice - min) / range) * (h - padding * 2),
+        y: toY(props.predictedPrice),
       };
     }
 
-    return { pts, predicted, min, max, range };
+    const lastMid = mids[mids.length - 1];
+    const predAbove = props.predictedPrice != null ? props.predictedPrice > lastMid : false;
+
+    return { highPts, lowPts, midPts, predicted, predAbove };
   });
 
-  const polyline = createMemo(() => {
+  // Spread band: path from highs forward then lows reversed
+  const spreadPath = createMemo(() => {
     const p = points();
     if (!p) return '';
-    return p.pts.map(pt => `${pt.x},${pt.y}`).join(' ');
+    const forward = p.highPts.map((pt, i) => (i === 0 ? `M${pt.x},${pt.y}` : `L${pt.x},${pt.y}`)).join(' ');
+    const backward = [...p.lowPts].reverse().map(pt => `L${pt.x},${pt.y}`).join(' ');
+    return `${forward} ${backward} Z`;
   });
 
+  // Midpoint polyline
+  const midline = createMemo(() => {
+    const p = points();
+    if (!p) return '';
+    return p.midPts.map(pt => `${pt.x},${pt.y}`).join(' ');
+  });
+
+  // Area fill below midpoint line
   const areaPath = createMemo(() => {
     const p = points();
     if (!p) return '';
     const h = height();
-    const pts = p.pts;
+    const pts = p.midPts;
     const first = pts[0];
     const last = pts[pts.length - 1];
     const line = pts.map(pt => `L${pt.x},${pt.y}`).join(' ');
@@ -77,17 +100,24 @@ export function Sparkline(props: SparklineProps) {
           <>
             <defs>
               <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stop-color="var(--accent)" stop-opacity="0.25" />
+                <stop offset="0%" stop-color="var(--accent)" stop-opacity="0.2" />
                 <stop offset="100%" stop-color="var(--accent)" stop-opacity="0" />
+              </linearGradient>
+              <linearGradient id={spreadGradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stop-color="var(--accent)" stop-opacity="0.12" />
+                <stop offset="100%" stop-color="var(--accent)" stop-opacity="0.04" />
               </linearGradient>
             </defs>
 
-            {/* Area fill */}
+            {/* Spread band (high-low range) */}
+            <path d={spreadPath()} fill={`url(#${spreadGradientId})`} />
+
+            {/* Area fill below midpoint */}
             <path d={areaPath()} fill={`url(#${gradientId})`} />
 
-            {/* History line */}
+            {/* Midpoint line */}
             <polyline
-              points={polyline()}
+              points={midline()}
               fill="none"
               stroke="var(--accent)"
               stroke-width="1.5"
@@ -98,7 +128,7 @@ export function Sparkline(props: SparklineProps) {
             {/* Current price dot */}
             {(() => {
               const p = points()!;
-              const last = p.pts[p.pts.length - 1];
+              const last = p.midPts[p.midPts.length - 1];
               return (
                 <circle
                   cx={last.x}
@@ -109,22 +139,31 @@ export function Sparkline(props: SparklineProps) {
               );
             })()}
 
-            {/* Predicted price dashed line */}
+            {/* Predicted price line + dot */}
             {points()!.predicted && (() => {
               const p = points()!;
-              const last = p.pts[p.pts.length - 1];
+              const last = p.midPts[p.midPts.length - 1];
               const pred = p.predicted!;
+              const color = p.predAbove ? 'var(--success)' : 'var(--danger)';
               return (
-                <line
-                  x1={last.x}
-                  y1={last.y}
-                  x2={pred.x}
-                  y2={pred.y}
-                  stroke="var(--text-muted)"
-                  stroke-width="1"
-                  stroke-dasharray="3,2"
-                  stroke-linecap="round"
-                />
+                <>
+                  <line
+                    x1={last.x}
+                    y1={last.y}
+                    x2={pred.x}
+                    y2={pred.y}
+                    stroke={color}
+                    stroke-width="1.5"
+                    stroke-dasharray="3,2"
+                    stroke-linecap="round"
+                  />
+                  <circle
+                    cx={pred.x}
+                    cy={pred.y}
+                    r="2.5"
+                    fill={color}
+                  />
+                </>
               );
             })()}
           </>

--- a/packages/web/src/components/opportunities/OpportunityCard.tsx
+++ b/packages/web/src/components/opportunities/OpportunityCard.tsx
@@ -3,7 +3,7 @@ import { Show, For, createSignal, onMount } from 'solid-js';
 import type { Opportunity } from '../../lib/trade-types';
 import Tooltip from '../Tooltip';
 import { Sparkline } from '../Sparkline';
-import { fetchPriceHistory } from '../../lib/price-history';
+import { fetchPriceHistory, type PriceHistoryData } from '../../lib/price-history';
 
 interface OpportunityCardProps {
   opportunity: Opportunity;
@@ -15,11 +15,11 @@ interface OpportunityCardProps {
 
 export function OpportunityCard(props: OpportunityCardProps) {
   const opp = () => props.opportunity;
-  const [priceHistory, setPriceHistory] = createSignal<number[] | null>(null);
+  const [priceHistory, setPriceHistory] = createSignal<PriceHistoryData | null>(null);
 
   onMount(() => {
-    fetchPriceHistory(opp().itemId).then(prices => {
-      if (prices) setPriceHistory(prices);
+    fetchPriceHistory(opp().itemId).then(data => {
+      if (data) setPriceHistory(data);
     });
   });
 
@@ -83,7 +83,8 @@ export function OpportunityCard(props: OpportunityCardProps) {
       <Show when={priceHistory()}>
         <div class="opportunity-card-sparkline">
           <Sparkline
-            prices={priceHistory()!}
+            highs={priceHistory()!.highs}
+            lows={priceHistory()!.lows}
             predictedPrice={opp().sellPrice}
             width={props.expanded ? 280 : 160}
             height={props.expanded ? 40 : 28}

--- a/packages/web/src/components/trades/TradeCard.tsx
+++ b/packages/web/src/components/trades/TradeCard.tsx
@@ -4,7 +4,7 @@ import type { TradeViewModel } from '../../lib/trade-types';
 import type { UpdateRecommendation } from '../../lib/types';
 import Tooltip from '../Tooltip';
 import { Sparkline } from '../Sparkline';
-import { fetchPriceHistory } from '../../lib/price-history';
+import { fetchPriceHistory, type PriceHistoryData } from '../../lib/price-history';
 
 interface TradeCardProps {
   trade: TradeViewModel;
@@ -15,11 +15,11 @@ interface TradeCardProps {
 }
 
 export function TradeCard(props: TradeCardProps) {
-  const [priceHistory, setPriceHistory] = createSignal<number[] | null>(null);
+  const [priceHistory, setPriceHistory] = createSignal<PriceHistoryData | null>(null);
 
   onMount(() => {
-    fetchPriceHistory(props.trade.itemId).then(prices => {
-      if (prices) setPriceHistory(prices);
+    fetchPriceHistory(props.trade.itemId).then(data => {
+      if (data) setPriceHistory(data);
     });
   });
 
@@ -68,7 +68,8 @@ export function TradeCard(props: TradeCardProps) {
       {priceHistory() && (
         <div class="trade-card-sparkline">
           <Sparkline
-            prices={priceHistory()!}
+            highs={priceHistory()!.highs}
+            lows={priceHistory()!.lows}
             predictedPrice={props.trade.sellPrice}
             width={160}
             height={28}

--- a/packages/web/src/components/trades/TradeDetail.tsx
+++ b/packages/web/src/components/trades/TradeDetail.tsx
@@ -6,7 +6,7 @@ import { CheckInBar } from './CheckInBar';
 import { GuidancePrompt } from './GuidancePrompt';
 import { AlertBanner } from './AlertBanner';
 import { Sparkline } from '../Sparkline';
-import { fetchPriceHistory } from '../../lib/price-history';
+import { fetchPriceHistory, type PriceHistoryData } from '../../lib/price-history';
 
 interface TradeDetailProps {
   trade: TradeViewModel;
@@ -21,11 +21,11 @@ interface TradeDetailProps {
 }
 
 export function TradeDetail(props: TradeDetailProps) {
-  const [priceHistory, setPriceHistory] = createSignal<number[] | null>(null);
+  const [priceHistory, setPriceHistory] = createSignal<PriceHistoryData | null>(null);
 
   onMount(() => {
-    fetchPriceHistory(props.trade.itemId).then(prices => {
-      if (prices) setPriceHistory(prices);
+    fetchPriceHistory(props.trade.itemId).then(data => {
+      if (data) setPriceHistory(data);
     });
   });
   const [loading, setLoading] = createSignal(false);
@@ -139,7 +139,8 @@ export function TradeDetail(props: TradeDetailProps) {
       <Show when={priceHistory()}>
         <div class="trade-detail-sparkline">
           <Sparkline
-            prices={priceHistory()!}
+            highs={priceHistory()!.highs}
+            lows={priceHistory()!.lows}
             predictedPrice={props.trade.sellPrice}
             width={280}
             height={48}

--- a/packages/web/src/lib/price-history.ts
+++ b/packages/web/src/lib/price-history.ts
@@ -1,16 +1,25 @@
 // Shared price history fetcher with module-level cache
 
-const priceHistoryCache = new Map<number, number[]>();
+export interface PriceHistoryData {
+  highs: number[];
+  lows: number[];
+}
 
-export async function fetchPriceHistory(itemId: number): Promise<number[] | null> {
+const priceHistoryCache = new Map<number, PriceHistoryData>();
+
+export async function fetchPriceHistory(itemId: number): Promise<PriceHistoryData | null> {
   if (priceHistoryCache.has(itemId)) return priceHistoryCache.get(itemId)!;
   try {
     const res = await fetch(`/api/items/price-history/${itemId}`);
     if (!res.ok) return null;
     const data = await res.json();
-    if (data.success && data.data?.prices?.length) {
-      priceHistoryCache.set(itemId, data.data.prices);
-      return data.data.prices;
+    if (data.success && data.data?.highs?.length && data.data?.lows?.length) {
+      const result: PriceHistoryData = {
+        highs: data.data.highs,
+        lows: data.data.lows,
+      };
+      priceHistoryCache.set(itemId, result);
+      return result;
     }
     return null;
   } catch {

--- a/packages/web/src/pages/api/items/price-history/[itemId].ts
+++ b/packages/web/src/pages/api/items/price-history/[itemId].ts
@@ -5,7 +5,8 @@ const PREDICTION_API = import.meta.env.PREDICTION_API;
 const API_KEY = import.meta.env.PREDICTION_API_KEY;
 
 interface PriceHistoryCache {
-  prices: number[];
+  highs: number[];
+  lows: number[];
   trend: string;
 }
 
@@ -69,13 +70,17 @@ export const GET: APIRoute = async ({ params, locals }) => {
 
       const raw = await engineRes.json();
 
-      // Simplify extended price points to midpoint array for sparklines
-      const prices: number[] = (raw.history ?? []).map(
-        (pt: { high: number; low: number }) => Math.round((pt.high + pt.low) / 2)
-      );
+      const history = raw.history ?? [];
+      const highs: number[] = history
+        .map((pt: { high: number }) => Math.round(pt.high))
+        .filter((v: number) => !isNaN(v));
+      const lows: number[] = history
+        .map((pt: { low: number }) => Math.round(pt.low))
+        .filter((v: number) => !isNaN(v));
 
       data = {
-        prices,
+        highs,
+        lows,
         trend: raw.trend ?? 'Stable',
       };
 


### PR DESCRIPTION
## Summary
- Pass through high/low price arrays from engine instead of collapsing to midpoints
- Render shaded band between high and low lines showing the price spread
- Color prediction dashed line + dot green when predicted > current, red when below
- Add filled circle at predicted price endpoint for visibility

## Test plan
- [ ] Verify sparklines show a subtle shaded band (spread) behind the midpoint line
- [ ] Verify predicted price line is green (sell price > current) or red (below)
- [ ] Verify predicted price has a dot at the endpoint
- [ ] Check both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)