### PR TITLE
fix: sparkline prediction layout and stale cache

### DIFF
--- a/packages/web/src/components/Sparkline.tsx
+++ b/packages/web/src/components/Sparkline.tsx
@@ -37,7 +37,10 @@ export function Sparkline(props: SparklineProps) {
 
     const w = width();
     const h = height();
-    const xStep = (w - padding * 2) / (len - 1);
+    // Reserve 15% of width for prediction projection when prediction exists
+    const hasPred = props.predictedPrice != null;
+    const historyWidth = hasPred ? (w - padding * 2) * 0.85 : (w - padding * 2);
+    const xStep = historyWidth / (len - 1);
 
     const toY = (val: number) => padding + (1 - (val - min) / range) * (h - padding * 2);
 

--- a/packages/web/src/pages/api/items/price-history/[itemId].ts
+++ b/packages/web/src/pages/api/items/price-history/[itemId].ts
@@ -44,12 +44,15 @@ export const GET: APIRoute = async ({ params, locals }) => {
   }
 
   try {
-    const redisCacheKey = cacheKey(KEY.ITEM_PRICE, 'history', itemId.toString());
+    const redisCacheKey = cacheKey(KEY.ITEM_PRICE, 'history:v2', itemId.toString());
 
     // Try cache first
     let data: PriceHistoryCache | null = null;
     try {
-      data = await cache.get<PriceHistoryCache>(redisCacheKey);
+      const cached = await cache.get<PriceHistoryCache>(redisCacheKey);
+      if (cached && Array.isArray(cached.highs) && Array.isArray(cached.lows)) {
+        data = cached;
+      }
     } catch (err) {
       console.warn('[PriceHistory] Cache read failed:', (err as Error)?.message);
     }


### PR DESCRIPTION
## Summary
- Reserve 15% of chart width for prediction projection — the dashed line now extends diagonally to the right instead of spiking vertically on top of the last data point
- Bump cache key to `history:v2` to invalidate stale Redis entries with the old `{ prices }` shape (from before the highs/lows change)
- Add cache shape validation so stale entries are re-fetched

## Test plan
- [ ] Sparklines show prediction line extending diagonally to the right
- [ ] No vertical spike at the end of the chart
- [ ] Sparklines load on all cards (stale cache cleared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)