### PR TITLE
fix: remove bogus predictions, show high/low spread lines

### DIFF
--- a/packages/web/src/components/Sparkline.tsx
+++ b/packages/web/src/components/Sparkline.tsx
@@ -4,7 +4,6 @@ import { createMemo } from 'solid-js';
 interface SparklineProps {
   highs: number[];
   lows: number[];
-  predictedPrice?: number;
   width?: number;
   height?: number;
   class?: string;
@@ -15,7 +14,6 @@ export function Sparkline(props: SparklineProps) {
   const height = () => props.height ?? 32;
   const padding = 2;
 
-  const gradientId = `spark-grad-${Math.random().toString(36).slice(2, 8)}`;
   const spreadGradientId = `spark-spread-${Math.random().toString(36).slice(2, 8)}`;
 
   const points = createMemo(() => {
@@ -24,45 +22,23 @@ export function Sparkline(props: SparklineProps) {
     const len = Math.min(highs?.length ?? 0, lows?.length ?? 0);
     if (len < 2) return null;
 
-    // Compute midpoints
-    const mids = Array.from({ length: len }, (_, i) => (highs[i] + lows[i]) / 2);
-
-    // Global min/max includes spread and prediction
     const allValues = [...highs.slice(0, len), ...lows.slice(0, len)];
-    if (props.predictedPrice != null) allValues.push(props.predictedPrice);
-
     const min = Math.min(...allValues);
     const max = Math.max(...allValues);
     const range = max - min || 1;
 
     const w = width();
     const h = height();
-    // Reserve 15% of width for prediction projection when prediction exists
-    const hasPred = props.predictedPrice != null;
-    const historyWidth = hasPred ? (w - padding * 2) * 0.85 : (w - padding * 2);
-    const xStep = historyWidth / (len - 1);
-
+    const xStep = (w - padding * 2) / (len - 1);
     const toY = (val: number) => padding + (1 - (val - min) / range) * (h - padding * 2);
 
     const highPts = highs.slice(0, len).map((v, i) => ({ x: padding + i * xStep, y: toY(v) }));
     const lowPts = lows.slice(0, len).map((v, i) => ({ x: padding + i * xStep, y: toY(v) }));
-    const midPts = mids.map((v, i) => ({ x: padding + i * xStep, y: toY(v) }));
 
-    let predicted: { x: number; y: number } | null = null;
-    if (props.predictedPrice != null) {
-      predicted = {
-        x: w - padding,
-        y: toY(props.predictedPrice),
-      };
-    }
-
-    const lastMid = mids[mids.length - 1];
-    const predAbove = props.predictedPrice != null ? props.predictedPrice > lastMid : false;
-
-    return { highPts, lowPts, midPts, predicted, predAbove };
+    return { highPts, lowPts };
   });
 
-  // Spread band: path from highs forward then lows reversed
+  // Spread band: highs forward, lows reversed
   const spreadPath = createMemo(() => {
     const p = points();
     if (!p) return '';
@@ -71,23 +47,18 @@ export function Sparkline(props: SparklineProps) {
     return `${forward} ${backward} Z`;
   });
 
-  // Midpoint polyline
-  const midline = createMemo(() => {
+  // High line polyline
+  const highLine = createMemo(() => {
     const p = points();
     if (!p) return '';
-    return p.midPts.map(pt => `${pt.x},${pt.y}`).join(' ');
+    return p.highPts.map(pt => `${pt.x},${pt.y}`).join(' ');
   });
 
-  // Area fill below midpoint line
-  const areaPath = createMemo(() => {
+  // Low line polyline
+  const lowLine = createMemo(() => {
     const p = points();
     if (!p) return '';
-    const h = height();
-    const pts = p.midPts;
-    const first = pts[0];
-    const last = pts[pts.length - 1];
-    const line = pts.map(pt => `L${pt.x},${pt.y}`).join(' ');
-    return `M${first.x},${h} ${line} L${last.x},${h} Z`;
+    return p.lowPts.map(pt => `${pt.x},${pt.y}`).join(' ');
   });
 
   return (
@@ -102,25 +73,29 @@ export function Sparkline(props: SparklineProps) {
         {points() && (
           <>
             <defs>
-              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stop-color="var(--accent)" stop-opacity="0.2" />
-                <stop offset="100%" stop-color="var(--accent)" stop-opacity="0" />
-              </linearGradient>
               <linearGradient id={spreadGradientId} x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stop-color="var(--accent)" stop-opacity="0.12" />
-                <stop offset="100%" stop-color="var(--accent)" stop-opacity="0.04" />
+                <stop offset="0%" stop-color="var(--accent)" stop-opacity="0.15" />
+                <stop offset="100%" stop-color="var(--accent)" stop-opacity="0.03" />
               </linearGradient>
             </defs>
 
-            {/* Spread band (high-low range) */}
+            {/* Spread band fill between high and low */}
             <path d={spreadPath()} fill={`url(#${spreadGradientId})`} />
 
-            {/* Area fill below midpoint */}
-            <path d={areaPath()} fill={`url(#${gradientId})`} />
-
-            {/* Midpoint line */}
+            {/* Low line */}
             <polyline
-              points={midline()}
+              points={lowLine()}
+              fill="none"
+              stroke="var(--accent)"
+              stroke-width="1"
+              stroke-opacity="0.4"
+              stroke-linejoin="round"
+              stroke-linecap="round"
+            />
+
+            {/* High line */}
+            <polyline
+              points={highLine()}
               fill="none"
               stroke="var(--accent)"
               stroke-width="1.5"
@@ -128,45 +103,17 @@ export function Sparkline(props: SparklineProps) {
               stroke-linecap="round"
             />
 
-            {/* Current price dot */}
+            {/* Current high price dot */}
             {(() => {
               const p = points()!;
-              const last = p.midPts[p.midPts.length - 1];
+              const last = p.highPts[p.highPts.length - 1];
               return (
                 <circle
                   cx={last.x}
                   cy={last.y}
-                  r="2.5"
+                  r="2"
                   fill="var(--accent)"
                 />
-              );
-            })()}
-
-            {/* Predicted price line + dot */}
-            {points()!.predicted && (() => {
-              const p = points()!;
-              const last = p.midPts[p.midPts.length - 1];
-              const pred = p.predicted!;
-              const color = p.predAbove ? 'var(--success)' : 'var(--danger)';
-              return (
-                <>
-                  <line
-                    x1={last.x}
-                    y1={last.y}
-                    x2={pred.x}
-                    y2={pred.y}
-                    stroke={color}
-                    stroke-width="1.5"
-                    stroke-dasharray="3,2"
-                    stroke-linecap="round"
-                  />
-                  <circle
-                    cx={pred.x}
-                    cy={pred.y}
-                    r="2.5"
-                    fill={color}
-                  />
-                </>
               );
             })()}
           </>

--- a/packages/web/src/components/opportunities/OpportunityCard.tsx
+++ b/packages/web/src/components/opportunities/OpportunityCard.tsx
@@ -85,7 +85,7 @@ export function OpportunityCard(props: OpportunityCardProps) {
           <Sparkline
             highs={priceHistory()!.highs}
             lows={priceHistory()!.lows}
-            predictedPrice={opp().sellPrice}
+
             width={props.expanded ? 280 : 160}
             height={props.expanded ? 40 : 28}
           />

--- a/packages/web/src/components/trades/TradeCard.tsx
+++ b/packages/web/src/components/trades/TradeCard.tsx
@@ -70,7 +70,6 @@ export function TradeCard(props: TradeCardProps) {
           <Sparkline
             highs={priceHistory()!.highs}
             lows={priceHistory()!.lows}
-            predictedPrice={props.trade.sellPrice}
             width={160}
             height={28}
           />

--- a/packages/web/src/components/trades/TradeDetail.tsx
+++ b/packages/web/src/components/trades/TradeDetail.tsx
@@ -141,7 +141,6 @@ export function TradeDetail(props: TradeDetailProps) {
           <Sparkline
             highs={priceHistory()!.highs}
             lows={priceHistory()!.lows}
-            predictedPrice={props.trade.sellPrice}
             width={280}
             height={48}
           />


### PR DESCRIPTION
## Summary
- Remove `predictedPrice` from sparklines — the sell price is a target GE offer, not a price prediction, so it made every chart look identical with a fake upward spike
- Draw two distinct lines: **high** (solid accent) and **low** (lighter opacity accent)
- Gradient-filled spread band between the two lines
- Dot on the latest high price point

## Test plan
- [ ] Sparklines show two lines (high/low) with visible spread between them
- [ ] No prediction line/dot
- [ ] Each item's chart looks unique based on its actual price history

🤖 Generated with [Claude Code](https://claude.com/claude-code)