### PR TITLE
feat: add dismissible Discord banner below nav

### DIFF
--- a/packages/web/src/layouts/Layout.astro
+++ b/packages/web/src/layouts/Layout.astro
@@ -164,6 +164,14 @@ const fullTitle = `${title} | GePT`;
       } catch {
         document.documentElement.dataset.theme = 'dark';
       }
+      // Hide dismissed Discord banner immediately to prevent flash
+      try {
+        if (localStorage.getItem('discord-banner-dismissed')) {
+          document.getElementById('discord-banner')?.remove();
+        }
+      } catch {
+        // localStorage unavailable (private browsing, disabled storage) - show banner
+      }
     </script>
     <script>
       function initPage() {
@@ -188,20 +196,18 @@ const fullTitle = `${title} | GePT`;
           menuBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
         });
 
-        // Discord banner dismiss
+        // Discord banner dismiss (banner may already be removed by the immediate script)
         const banner = document.getElementById('discord-banner');
-        const dismissBtn = document.getElementById('discord-banner-dismiss');
         if (banner) {
-          try {
-            if (localStorage.getItem('discord-banner-dismissed')) {
-              banner.remove();
+          document.getElementById('discord-banner-dismiss')?.addEventListener('click', () => {
+            banner.remove();
+            try {
+              localStorage.setItem('discord-banner-dismissed', '1');
+            } catch {
+              // Storage unavailable - dismiss works for current page view only
             }
-          } catch {}
+          });
         }
-        dismissBtn?.addEventListener('click', () => {
-          banner?.remove();
-          try { localStorage.setItem('discord-banner-dismissed', '1'); } catch {}
-        });
       }
 
       // Run on initial load and after each navigation


### PR DESCRIPTION
## Summary
- Adds a full-width Discord-branded banner strip below the navigation bar on all pages
- Banner includes Discord icon, invite message, and "Join Server" CTA pill button
- Dismissible via X button; persists dismissal in localStorage
- Responsive: hides CTA pill on mobile, allows text wrapping

## Test plan
- [ ] Verify banner appears on all pages below the nav
- [ ] Click the banner link opens Discord invite in new tab
- [ ] Click dismiss removes the banner and it stays hidden on reload/navigation
- [ ] Clear localStorage `discord-banner-dismissed` key to re-show banner
- [ ] Check mobile layout: CTA hidden, text wraps properly
- [ ] Verify light and dark themes both render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)