### PR TITLE
fix: persist Discord banner dismissal across view transitions

### DIFF
--- a/packages/web/src/layouts/Layout.astro
+++ b/packages/web/src/layouts/Layout.astro
@@ -196,17 +196,28 @@ const fullTitle = `${title} | GePT`;
           menuBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
         });
 
-        // Discord banner dismiss (banner may already be removed by the immediate script)
+        // Discord banner dismiss
+        // The synchronous script handles initial hard load; this handles view transition navigations
         const banner = document.getElementById('discord-banner');
         if (banner) {
-          document.getElementById('discord-banner-dismiss')?.addEventListener('click', () => {
+          let dismissed = false;
+          try {
+            dismissed = !!localStorage.getItem('discord-banner-dismissed');
+          } catch {
+            // localStorage unavailable - show banner
+          }
+          if (dismissed) {
             banner.remove();
-            try {
-              localStorage.setItem('discord-banner-dismissed', '1');
-            } catch {
-              // Storage unavailable - dismiss works for current page view only
-            }
-          });
+          } else {
+            document.getElementById('discord-banner-dismiss')?.addEventListener('click', () => {
+              banner.remove();
+              try {
+                localStorage.setItem('discord-banner-dismissed', '1');
+              } catch {
+                // Storage unavailable - dismiss works for current page view only
+              }
+            });
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- Fix banner reappearing after dismissal when navigating via Astro View Transitions
- The synchronous script only runs on hard page loads; `initPage()` now also checks localStorage and removes the banner on soft navigations
- Only registers the click handler when the banner hasn't been previously dismissed

## Test plan
- [ ] Dismiss the banner, navigate between pages — banner should stay hidden
- [ ] Hard refresh after dismissal — banner should stay hidden (no flash)
- [ ] Clear `discord-banner-dismissed` from localStorage — banner reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)