### PR TITLE
Restore price alert webhook validation and resync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ packages/model/data/
 .claude/
 agents/
 docs/
+packages/engine/docs/server_setup.md
 infra/runbooks/
 CLAUDE.md
 .worktrees/


### PR DESCRIPTION
## Summary
- Add fail-fast webhook validation for price-drop monitor
- Add startup resync of active trades
- Gate monitor via PRICE_DROP_MONITOR_ENABLED
- Update env examples and web docs

## Testing
- packages/engine/venv/bin/python -m pytest packages/engine/tests/test_api.py -k "validate_rejects_missing_webhook_config_when_monitor_enabled or validate_allows_missing_webhook_config_when_monitor_disabled"