### PR TITLE
Use runtime env for prediction API key

### DIFF
--- a/packages/web/src/pages/api/items/price-history/[itemId].ts
+++ b/packages/web/src/pages/api/items/price-history/[itemId].ts
@@ -2,7 +2,7 @@ import type { APIRoute } from 'astro';
 import { cache, cacheKey, TTL, KEY } from '../../../../lib/cache';
 
 const PREDICTION_API = import.meta.env.PREDICTION_API;
-const API_KEY = import.meta.env.PREDICTION_API_KEY;
+const API_KEY = process.env.PREDICTION_API_KEY ?? import.meta.env.PREDICTION_API_KEY;
 
 interface PriceHistoryCache {
   highs: number[];

--- a/packages/web/src/pages/api/opportunities.ts
+++ b/packages/web/src/pages/api/opportunities.ts
@@ -3,7 +3,7 @@ import type { APIRoute } from 'astro';
 import { cache, cacheKey, TTL, KEY } from '../../lib/cache';
 
 const PREDICTION_API = import.meta.env.PREDICTION_API;
-const API_KEY = import.meta.env.PREDICTION_API_KEY;
+const API_KEY = process.env.PREDICTION_API_KEY ?? import.meta.env.PREDICTION_API_KEY;
 
 export const POST: APIRoute = async ({ request, locals }) => {
   // Require authentication


### PR DESCRIPTION
## Summary
- read prediction API key from runtime env when available
- keep import.meta.env fallback for build-time injection

## Why
- fixes production 401s when Vercel env changes aren't baked into the build
