### PR TITLE
Read prediction API URL from runtime env

### DIFF
--- a/packages/web/src/pages/api/items/price-history/[itemId].ts
+++ b/packages/web/src/pages/api/items/price-history/[itemId].ts
@@ -2,7 +2,7 @@ import type { APIRoute } from 'astro';
 import { createHash } from 'crypto';
 import { cache, cacheKey, TTL, KEY } from '../../../../lib/cache';
 
-const PREDICTION_API = import.meta.env.PREDICTION_API;
+const PREDICTION_API = process.env.PREDICTION_API ?? import.meta.env.PREDICTION_API;
 const API_KEY = process.env.PREDICTION_API_KEY ?? import.meta.env.PREDICTION_API_KEY;
 const API_KEY_SOURCE = process.env.PREDICTION_API_KEY
   ? 'process.env'

--- a/packages/web/src/pages/api/opportunities.ts
+++ b/packages/web/src/pages/api/opportunities.ts
@@ -3,7 +3,7 @@ import type { APIRoute } from 'astro';
 import { createHash } from 'crypto';
 import { cache, cacheKey, TTL, KEY } from '../../lib/cache';
 
-const PREDICTION_API = import.meta.env.PREDICTION_API;
+const PREDICTION_API = process.env.PREDICTION_API ?? import.meta.env.PREDICTION_API;
 const API_KEY = process.env.PREDICTION_API_KEY ?? import.meta.env.PREDICTION_API_KEY;
 const API_KEY_SOURCE = process.env.PREDICTION_API_KEY
   ? 'process.env'


### PR DESCRIPTION
## Summary
- prefer process.env.PREDICTION_API in web API routes
- keep import.meta.env fallback

## Why
- avoid build-time env drift on Vercel
