### PR TITLE
Add beta model toggle to account settings

### DIFF
--- a/packages/engine/src/api.py
+++ b/packages/engine/src/api.py
@@ -1431,6 +1431,10 @@ async def get_recommendations_get(
         default=False,
         description="If true, return all viable flips sorted by score instead of slot-limited portfolio",
     ),
+    use_beta_model: bool = Query(
+        default=False,
+        description="Use beta model predictions if available",
+    ),
 ):
     """Get recommendations via GET request.
 
@@ -1488,6 +1492,7 @@ async def get_recommendations_get(
                 max_offset_pct=max_offset_pct,
                 max_hour_offset=max_hour_offset,
                 min_ev=min_ev,
+                use_beta_model=use_beta_model,
             )
 
             # Generate timestamps for response
@@ -1515,6 +1520,7 @@ async def get_recommendations_get(
             max_offset_pct=max_offset_pct,
             max_hour_offset=max_hour_offset,
             min_ev=min_ev,
+            use_beta_model=use_beta_model,
         )
 
         # Return with or without metadata based on request

--- a/packages/engine/src/config.py
+++ b/packages/engine/src/config.py
@@ -189,6 +189,13 @@ class Config:
         default_factory=lambda: environ.get("PREFERRED_MODEL_ID", "")
     )
 
+    # Beta model ID - shadow/experimental model for opt-in users
+    # Set to a specific model_id to enable the beta model toggle
+    # Leave empty to disable the beta model feature
+    beta_model_id: str = field(
+        default_factory=lambda: environ.get("BETA_MODEL_ID", "")
+    )
+
     # Logging configuration
     # LOG_LEVEL: DEBUG, INFO, WARNING, ERROR (default: INFO)
     # LOG_FORMAT: json (for production), text (for local development)

--- a/packages/web/migrations/003_add_use_beta_model.sql
+++ b/packages/web/migrations/003_add_use_beta_model.sql
@@ -1,0 +1,3 @@
+-- Add use_beta_model toggle to users table
+-- Allows users to opt into predictions from a shadow/experimental model
+ALTER TABLE users ADD COLUMN IF NOT EXISTS use_beta_model BOOLEAN NOT NULL DEFAULT false;

--- a/packages/web/src/components/Settings.tsx
+++ b/packages/web/src/components/Settings.tsx
@@ -3,6 +3,7 @@ import { type AppSettings, defaultAppSettings } from '../lib/types';
 
 interface UserSettings {
   tier: 'free' | 'premium';
+  useBetaModel: boolean;
 }
 
 interface RateLimitInfo {
@@ -178,6 +179,21 @@ export default function Settings() {
             </div>
             <p class="rate-limit-tier text-sm text-muted mt-2">
               Tier: <span class="font-medium">{settings()!.tier}</span>
+            </p>
+          </div>
+
+          {/* Beta Model Toggle */}
+          <div class="form-group" style={{ "margin-bottom": "var(--space-4)" }}>
+            <label class="toggle-label">
+              <input
+                type="checkbox"
+                checked={settings()!.useBetaModel}
+                onChange={(e) => updateSetting('useBetaModel', e.currentTarget.checked)}
+              />
+              <span>Use beta model if available</span>
+            </label>
+            <p class="text-sm text-muted" style={{ "margin-top": "var(--space-1)", "margin-left": "calc(18px + var(--space-3))" }}>
+              Try our latest prediction model. Beta models may be less stable but can offer improved accuracy.
             </p>
           </div>
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -196,6 +196,10 @@ export async function getRecommendations(
     params.append('exclude_item_ids', settings.excludedItems.join(','));
   }
 
+  if (settings.useBetaModel) {
+    params.append('use_beta_model', 'true');
+  }
+
   const url = `${getApiBase()}/api/v1/recommendations?${params}`;
   const apiResponse = await fetchWithRetry<ApiRecommendation[]>(url);
   return apiResponse.map(transformRecommendation);

--- a/packages/web/src/lib/db.ts
+++ b/packages/web/src/lib/db.ts
@@ -35,6 +35,7 @@ export interface User {
   tier: 'beta' | 'free' | 'premium';
   tutorial_completed: boolean;
   excluded_items: string[];
+  use_beta_model: boolean;
   daily_query_count: number;
   daily_reset_date: string | null;
   weekly_query_count: number;

--- a/packages/web/src/lib/repositories.ts
+++ b/packages/web/src/lib/repositories.ts
@@ -43,6 +43,7 @@ export const userRepo = {
         min_roi = COALESCE(${(data as Record<string, unknown>).min_roi ?? null}, min_roi),
         tier = COALESCE(${(data as Record<string, unknown>).tier ?? null}, tier),
         tutorial_completed = COALESCE(${(data as Record<string, unknown>).tutorial_completed ?? null}, tutorial_completed),
+        use_beta_model = COALESCE(${(data as Record<string, unknown>).use_beta_model ?? null}, use_beta_model),
         updated_at = NOW()
       WHERE id = ${id}
     `;

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -35,6 +35,7 @@ export interface UserSettings {
   risk: 'low' | 'medium' | 'high';
   margin: 'conservative' | 'moderate' | 'aggressive';
   excludedItems?: number[];
+  useBetaModel?: boolean;
 }
 
 // Item search result

--- a/packages/web/src/pages/api/recommendations.ts
+++ b/packages/web/src/pages/api/recommendations.ts
@@ -71,8 +71,11 @@ export const GET: APIRoute = async ({ locals, request }) => {
     // Check if client requested fresh data (bypass cache)
     const skipCache = url.searchParams.get('fresh') === '1';
 
+    // Check if user wants beta model predictions
+    const useBetaModel = user.use_beta_model === true;
+
     // Build cache key based on effective settings (use exact capital for accuracy)
-    const redisCacheKey = cacheKey(KEY.RECS, userId, capital.toString(), effectiveStyle, effectiveRisk, effectiveMargin);
+    const redisCacheKey = cacheKey(KEY.RECS, userId, capital.toString(), effectiveStyle, effectiveRisk, effectiveMargin, useBetaModel ? 'beta' : 'prod');
 
     // Try Redis cache first (unless fresh=1 requested)
     let recommendations: Awaited<ReturnType<typeof getRecommendations>> | null = null;
@@ -92,7 +95,8 @@ export const GET: APIRoute = async ({ locals, request }) => {
         style: effectiveStyle,
         risk: effectiveRisk,
         margin: effectiveMargin,
-        excludedItems: [] // Don't exclude at API level - filter client-side for flexibility
+        excludedItems: [], // Don't exclude at API level - filter client-side for flexibility
+        useBetaModel
       }, requestedSlots);
 
       // Cache for 30 seconds (fire and forget)

--- a/packages/web/src/pages/api/settings.ts
+++ b/packages/web/src/pages/api/settings.ts
@@ -29,7 +29,8 @@ export const GET: APIRoute = async ({ locals }) => {
           slots: user.slots,
           min_roi: user.min_roi,
           tier: user.tier,
-          tutorialCompleted: user.tutorial_completed
+          tutorialCompleted: user.tutorial_completed,
+          useBetaModel: user.use_beta_model
         },
         rateLimit
       }
@@ -62,7 +63,7 @@ export const PUT: APIRoute = async ({ request, locals }) => {
 
     const userId = locals.user.id;
     const body = await request.json();
-    const { capital, style, risk, margin, slots, min_roi, tutorialCompleted } = body;
+    const { capital, style, risk, margin, slots, min_roi, tutorialCompleted, useBetaModel } = body;
 
     const updates: Record<string, unknown> = {};
 
@@ -94,6 +95,10 @@ export const PUT: APIRoute = async ({ request, locals }) => {
       updates.tutorial_completed = tutorialCompleted;
     }
 
+    if (useBetaModel !== undefined && typeof useBetaModel === 'boolean') {
+      updates.use_beta_model = useBetaModel;
+    }
+
     if (Object.keys(updates).length > 0) {
       await userRepo.update(userId, updates);
 
@@ -114,7 +119,8 @@ export const PUT: APIRoute = async ({ request, locals }) => {
         slots: user?.slots,
         min_roi: user?.min_roi,
         tier: user?.tier,
-        tutorialCompleted: user?.tutorial_completed
+        tutorialCompleted: user?.tutorial_completed,
+        useBetaModel: user?.use_beta_model
       }
     }), {
       status: 200,


### PR DESCRIPTION
## Summary
- Adds "Use beta model if available" toggle to Account Settings
- Users can opt into predictions from the shadow `gept_v2` model
- Engine maintains a dual `PredictionLoader` via `BETA_MODEL_ID` env var
- Graceful fallback to production model when beta is unconfigured

## Changes
- **Web**: Settings UI toggle, API read/write, cache key separation, engine param passthrough
- **Engine**: `BETA_MODEL_ID` config, dual loader in `RecommendationEngine`, `use_beta_model` query param
- **Migration**: `ALTER TABLE users ADD COLUMN use_beta_model BOOLEAN DEFAULT false`

## Deployment status
- Neon migration: applied
- Ampere engine: deployed and running with `BETA_MODEL_ID=gept_v2`
- Web (Vercel): pending this merge

## Test plan
- [ ] Toggle appears in Account Settings and persists
- [ ] With toggle on: recommendations use gept_v2 model
- [ ] With toggle off: recommendations use patchtst_patchtst (production)
- [ ] Cache keys differ between beta and production

🤖 Generated with [Claude Code](https://claude.com/claude-code)