### PR TITLE
Fix sparkline fallback + show overdue status

### DIFF
--- a/packages/web/src/components/opportunities/OpportunityCard.tsx
+++ b/packages/web/src/components/opportunities/OpportunityCard.tsx
@@ -162,19 +162,17 @@ export function OpportunityCard(props: OpportunityCardProps) {
               <span class="price-value">{formatExactGold(opp().sellPrice)}</span>
             </div>
           </div>
-          <Show when={!historyAttempted() || historyLoading() || priceHistory()}>
-            <div class="opportunity-card-sparkline-wrap">
-              <div class="opportunity-card-sparkline" aria-label="Price history">
-                <Sparkline
-                  highs={priceHistory()?.highs ?? []}
-                  lows={priceHistory()?.lows ?? []}
-                  loading={!priceHistory() && !historyAttempted()}
-                  width={280}
-                  height={56}
-                />
-              </div>
+          <div class="opportunity-card-sparkline-wrap">
+            <div class="opportunity-card-sparkline" aria-label="Price history">
+              <Sparkline
+                highs={priceHistory()?.highs ?? []}
+                lows={priceHistory()?.lows ?? []}
+                loading={!priceHistory() && !historyAttempted()}
+                width={280}
+                height={56}
+              />
             </div>
-          </Show>
+          </div>
           <div class="opportunity-card-quantity" onClick={(e) => e.stopPropagation()}>
             <span class="quantity-label">Quantity</span>
             <div class="quantity-control">

--- a/packages/web/src/components/trades/TradeCard.tsx
+++ b/packages/web/src/components/trades/TradeCard.tsx
@@ -70,7 +70,7 @@ export function TradeCard(props: TradeCardProps) {
         <div class="trade-card-center">
           {(props.alert || props.trade.suggestedSellPrice) ? (
             <span class="status-badge status-alert">Price alert</span>
-          ) : (props.trade.status === 'on_track' && isOverdue()) ? (
+          ) : isOverdue() ? (
             <span class="status-badge status-overdue">Overdue</span>
           ) : (
             getStatusBadge()

--- a/packages/web/src/components/trades/TradeDetail.tsx
+++ b/packages/web/src/components/trades/TradeDetail.tsx
@@ -175,17 +175,15 @@ export function TradeDetail(props: TradeDetailProps) {
         </div>
       </div>
 
-      <Show when={historyLoading() || priceHistory()}>
-        <div class="trade-detail-sparkline">
-          <Sparkline
-            highs={priceHistory()?.highs ?? []}
-            lows={priceHistory()?.lows ?? []}
-            loading={historyLoading() && !priceHistory()}
-            width={280}
-            height={56}
-          />
-        </div>
-      </Show>
+      <div class="trade-detail-sparkline">
+        <Sparkline
+          highs={priceHistory()?.highs ?? []}
+          lows={priceHistory()?.lows ?? []}
+          loading={historyLoading() && !priceHistory()}
+          width={280}
+          height={56}
+        />
+      </div>
 
       <Show when={props.alert}>
         <AlertBanner


### PR DESCRIPTION
Fixes two UI issues:

- Sparkline: keep the sparkline area rendered after loading and show an empty-state baseline/dot when price history is missing or has <2 points (instead of disappearing/going blank).
- Trade status: show "Overdue" when a trade has exceeded expected time, even if a check-in is also due.

Changes:
- packages/web/src/components/Sparkline.tsx: render empty-state baseline; handle 1-point history; center flat ranges.
- packages/web/src/components/trades/TradeDetail.tsx: always render sparkline container.
- packages/web/src/components/opportunities/OpportunityCard.tsx: always render sparkline container (expanded view).
- packages/web/src/components/trades/TradeCard.tsx: prioritize overdue badge.

Testing:
- npm run typecheck
- npm run build:web
