### PR TITLE
Fix overdue badge + sparkline empty-cache

### DIFF
--- a/packages/web/src/lib/trade-types.ts
+++ b/packages/web/src/lib/trade-types.ts
@@ -124,6 +124,11 @@ export function toTradeViewModel(trade: ActiveTrade): TradeViewModel {
   const now = new Date();
   const createdAt = new Date(trade.created_at);
   const nextCheckIn = trade.next_check_in ? new Date(trade.next_check_in) : null;
+  const expectedHoursRaw = trade.expected_hours;
+  const expectedHoursNum =
+    typeof expectedHoursRaw === 'number' ? expectedHoursRaw : Number(expectedHoursRaw);
+  const expectedHours =
+    Number.isFinite(expectedHoursNum) && expectedHoursNum > 0 ? expectedHoursNum : 4;
 
   // Compute status
   let status: TradeStatus = 'on_track';
@@ -149,7 +154,7 @@ export function toTradeViewModel(trade: ActiveTrade): TradeViewModel {
     targetProfit: (trade.sell_price - trade.buy_price) * trade.quantity,
     quantity: trade.quantity,
     createdAt,
-    expectedHours: trade.expected_hours || 4, // Default 4 hours
+    expectedHours,
     lastCheckIn: trade.last_check_in ? new Date(trade.last_check_in) : null,
     nextCheckIn,
     recId: trade.rec_id,


### PR DESCRIPTION
- Parse `expected_hours` to a number before computing overdue so trades at 68h show "Overdue" (Neon DECIMAL can come back as a string).\n- Avoid caching empty sparkline histories in Redis (and treat empty cached arrays as a miss) so transient engine/data issues don't hide sparklines for 5 minutes.