### PR TITLE
infra: run engine with 1 uvicorn worker

### DIFF
--- a/infra/systemd/gept-engine.service
+++ b/infra/systemd/gept-engine.service
@@ -10,7 +10,9 @@ WorkingDirectory=/home/ubuntu/gept/current/packages/engine
 Environment="PATH=/home/ubuntu/gept/venv/bin:/usr/bin"
 Environment="PYTHONUNBUFFERED=1"
 EnvironmentFile=/home/ubuntu/gept/.env
-ExecStart=/home/ubuntu/gept/venv/bin/uvicorn src.api:app --host 0.0.0.0 --port 8000 --workers 2
+# Single worker: the app starts background loops in FastAPI lifespan; multiple
+# workers would duplicate that work per process unless/until we split workers.
+ExecStart=/home/ubuntu/gept/venv/bin/uvicorn src.api:app --host 0.0.0.0 --port 8000 --workers 1
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
Phase 1.6: prevent duplicate background loops by running a single Uvicorn worker for the engine systemd unit.

Change
- infra/systemd/gept-engine.service: --workers 2 -> --workers 1

Why
- FastAPI lifespan starts background tasks; multiple workers would duplicate the work per process.