### PR TITLE
web: read webhook env vars at runtime

### DIFF
--- a/packages/web/src/pages/api/trades/resync.ts
+++ b/packages/web/src/pages/api/trades/resync.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { sql, type ActiveTrade } from '../../../lib/db';
-import { dispatchWebhook } from '../../../lib/webhook';
+import { dispatchWebhook, getWebhookSecret } from '../../../lib/webhook';
 
 /**
  * POST /api/trades/resync
@@ -12,7 +12,7 @@ import { dispatchWebhook } from '../../../lib/webhook';
  */
 export const POST: APIRoute = async ({ request }) => {
   try {
-    const secret = import.meta.env.WEBHOOK_SECRET || '';
+    const secret = getWebhookSecret();
     const authHeader = request.headers.get('Authorization') || '';
 
     if (!secret || authHeader !== `Bearer ${secret}`) {


### PR DESCRIPTION
Fixes webhook secret/URL lookup to use runtime `process.env` (Vercel-style), with a build-time fallback.

Why:
- If `WEBHOOK_SECRET`/`ENGINE_WEBHOOK_URL` are only available at runtime, build-time `import.meta.env` can be empty, breaking:
  - web -> engine trade webhooks (engine never sees active trades, so no price alerts)
  - engine -> web alerts signature verification

Changes:
- `packages/web/src/lib/webhook.ts`: runtime env getters + fail-closed outbound dispatch when secret missing
- `packages/web/src/pages/api/trades/resync.ts`: uses shared runtime secret getter
- `packages/web/scripts/test-middleware-auth.mjs`: adds production-build test for signed alerts webhook

Verification:
- `cd packages/web && npm test`