### PR TITLE
alerts: resync auth fallback header

### DIFF
--- a/packages/engine/src/api_lifespan.py
+++ b/packages/engine/src/api_lifespan.py
@@ -54,7 +54,12 @@ async def _resync_active_trades() -> None:
         logger.warning("Active trade resync skipped", reason="WEBHOOK_SECRET not configured")
         return
 
-    headers = {"Authorization": f"Bearer {config.webhook_secret}"}
+    headers = {
+        "Authorization": f"Bearer {config.webhook_secret}",
+        # Some WAF/CDN setups strip Authorization headers. Include a fallback header
+        # that the web app can verify.
+        "X-Gept-Webhook-Secret": config.webhook_secret,
+    }
 
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:


### PR DESCRIPTION
Why:
- Engine resync to `https://gept.gg/api/trades/resync` is still returning 401 even after aligning secrets.
- Many WAF/CDN setups strip `Authorization` headers; we already saw POST blocked (403) and had to move to GET.

Changes:
- Web `GET/POST /api/trades/resync`: accept `X-Gept-Webhook-Secret: <WEBHOOK_SECRET>` as a fallback to `Authorization: Bearer ...`.
- Engine resync request includes both headers.
- Adds a production-build test asserting resync auth passes via fallback header (expects non-401; may 500 without DATABASE_URL).

Verification:
- `cd packages/web && npm test`
- `python3 -m py_compile packages/engine/src/api_lifespan.py`