### PR TITLE
resync: include auth debug lengths

### DIFF
--- a/packages/web/src/pages/api/trades/resync.ts
+++ b/packages/web/src/pages/api/trades/resync.ts
@@ -30,8 +30,13 @@ async function handleResync(request: Request): Promise<Response> {
         // in production. If this endpoint is stable, we can remove later.
         debug: {
           secretConfigured: Boolean(secret),
+          secretLen: secret.length,
           authorizationPresent: Boolean(authHeader),
+          authorizationLen: authHeader.length,
           xGeptWebhookSecretPresent: Boolean(altSecret),
+          xGeptWebhookSecretLen: altSecret.length,
+          bearerOk,
+          headerOk,
         }
       }), {
         status: 401,


### PR DESCRIPTION
Extends the `/api/trades/resync` 401 debug payload with string lengths + which checks failed (no secret values).

This helps determine whether the mismatch is due to whitespace/quoting/stripping vs truly different secrets.