### PR TITLE
[codex] Fix price alert revise flow

### DIFF
--- a/packages/web/src/lib/mock-data.ts
+++ b/packages/web/src/lib/mock-data.ts
@@ -249,7 +249,8 @@ export const updateMockTradeProgress = (id: string, progress: number, nextCheckI
 
 export const updateMockTradeSellPrice = (id: string, sellPrice: number) => {
   mockTrades = mockTrades.map((trade) =>
-    trade.id === id ? { ...trade, sell_price: sellPrice } : trade
+    // Mirror prod behavior: accepting a suggested price clears the suggested flag.
+    trade.id === id ? { ...trade, sell_price: sellPrice, suggested_sell_price: null } : trade
   );
   return findMockTrade(id);
 };


### PR DESCRIPTION
## Problem
Price alerts show correctly and offer a "Revise price" action, but clicking it did not reliably update the trade UI and could immediately re-trigger the same alert again.

## Root Cause
1. The web UI `TradeList` component initialized its internal `trades` state from `initialTrades` only once. After accepting an alert, `HomePage` refetched trades, but `TradeList` did not react to the new props, so it could look like the trade never updated.
2. `/api/trades/updates` responses are cached briefly (Redis, TTL ~30s). After `PATCH /api/trades/active/:id`, the cache could still serve the same stale update recommendation, causing the alert to reappear quickly.

## Fix
- Keep `TradeList`'s internal list in sync with `initialTrades` so sell price revisions show up immediately after the parent refresh.
- Invalidate the cached updates key on trade PATCH so the next poll re-evaluates against the updated sell price.
- Align dev mock behavior with prod by clearing `suggested_sell_price` when updating a trade sell price.

## Validation
- `npm -w @gept/web run build`
- `npm -w @gept/web run test`

Notes: The web test logs include a `DATABASE_URL` warning when exercising routes that touch the DB in this environment; the auth/middleware assertions still pass.
