### PR TITLE
[codex] Run engine via docker compose

### DIFF
--- a/infra/systemd/gept-engine.service
+++ b/infra/systemd/gept-engine.service
@@ -1,20 +1,20 @@
 [Unit]
-Description=GePT Recommendation Engine API
-After=network.target postgresql.service
-Wants=postgresql.service
+Description=GePT Recommendation Engine API (Docker)
+After=network.target docker.service
+Wants=docker.service
 
 [Service]
-Type=simple
+Type=oneshot
+RemainAfterExit=yes
 User=ubuntu
 WorkingDirectory=/home/ubuntu/gept/current/packages/engine
-Environment="PATH=/home/ubuntu/gept/venv/bin:/usr/bin"
-Environment="PYTHONUNBUFFERED=1"
-EnvironmentFile=/home/ubuntu/gept/.env
-# Single worker: the app starts background loops in FastAPI lifespan; multiple
-# workers would duplicate that work per process unless/until we split workers.
-ExecStart=/home/ubuntu/gept/venv/bin/uvicorn src.api:app --host 0.0.0.0 --port 8000 --workers 1
-Restart=always
-RestartSec=10
+Environment="PATH=/usr/bin:/bin"
+# Always pull before starting so a `systemctl restart gept-engine` picks up the
+# latest image (or the tag specified by GEPT_ENGINE_TAG).
+ExecStartPre=/usr/bin/docker compose -f /home/ubuntu/gept/current/packages/engine/docker-compose.yml pull
+ExecStart=/usr/bin/docker compose -f /home/ubuntu/gept/current/packages/engine/docker-compose.yml up -d --remove-orphans
+ExecStop=/usr/bin/docker compose -f /home/ubuntu/gept/current/packages/engine/docker-compose.yml down
+TimeoutStartSec=300
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/engine/docker-compose.yml
+++ b/packages/engine/docker-compose.yml
@@ -1,18 +1,20 @@
 services:
   engine:
-    image: ghcr.io/marcusfranz/gept-engine:latest
+    image: ghcr.io/marcusfranz/gept-engine:${GEPT_ENGINE_TAG:-latest}
     container_name: gept-engine
     restart: unless-stopped
     network_mode: host
     env_file:
-      - .env
+      # Production host keeps secrets in /home/ubuntu/gept/.env (also used by systemd).
+      - /home/ubuntu/gept/.env
     volumes:
       # Mount ML ranker model from host (read-only)
       - /home/ubuntu/gept/models/ranker:/app/models/ranker:ro
       # Persist logs (optional - structured logs also go to stdout)
       - ./logs:/app/logs
+    command: ["uvicorn", "src.api:app", "--host", "127.0.0.1", "--port", "8001", "--workers", "1"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8001/healthz"]
       interval: 30s
       timeout: 5s
       start_period: 60s


### PR DESCRIPTION
## Summary
Switch the production recommendation engine service (`gept-engine.service`) from a Python virtualenv + uvicorn process to running via Docker Compose.

## Why
- Aligns production runtime with the Docker image built by CI (`ghcr.io/marcusfranz/gept-engine`).
- Makes deploys predictable: `systemctl restart gept-engine` now pulls the latest image and restarts the container.
- Keeps the existing nginx layout intact (nginx on :8000 proxying to engine on 127.0.0.1:8001).

## Changes
- `packages/engine/docker-compose.yml`
  - Use `ghcr.io/marcusfranz/gept-engine:${GEPT_ENGINE_TAG:-latest}`
  - Read env from `/home/ubuntu/gept/.env`
  - Run uvicorn on `127.0.0.1:8001`
  - Healthcheck against `127.0.0.1:8001/healthz`

- `infra/systemd/gept-engine.service`
  - Convert to a oneshot/RemainAfterExit unit that runs `docker compose pull` then `docker compose up -d`.

## Ops Notes
- Ensure the host has Docker + Compose installed and the `ubuntu` user can run Docker.
- Optional: set `GEPT_ENGINE_TAG=sha-<commit>` to pin a specific image tag.
