### PR TITLE
Web: Inline price alerts (no banner) + dismiss clears suggestion

### DIFF
--- a/packages/web/src/components/HomePage.tsx
+++ b/packages/web/src/components/HomePage.tsx
@@ -71,6 +71,23 @@ export function HomePage(props: HomePageProps) {
     }
   };
 
+  const handleDismissPriceAlert = async (tradeId: string) => {
+    try {
+      // Clear the persisted suggestion so the inline UI (and badge) disappears.
+      // Also ensures polling doesn't immediately recreate the same suggestion.
+      await fetch(`/api/trades/active/${tradeId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clearSuggestedSellPrice: true })
+      });
+    } catch (err) {
+      console.error('Failed to dismiss price alert:', err);
+    } finally {
+      dismissAlert(tradeId);
+      await handleTradeAdded();
+    }
+  };
+
   return (
     <div class="home-page">
       <nav class="home-nav">
@@ -105,7 +122,7 @@ export function HomePage(props: HomePageProps) {
             onNavigateToOpportunities={() => setActiveTab('opportunities')}
             alerts={alerts()}
             onAcceptAlert={handleAcceptAlert}
-            onDismissAlert={(tradeId) => dismissAlert(tradeId)}
+            onDismissAlert={(tradeId) => handleDismissPriceAlert(tradeId)}
           />
         </Show>
 


### PR DESCRIPTION
Removes the notification-style price alert banner and renders alerts as the integrated inline price UI (strike-through + new price + check).\n\nChanges:\n- TradeDetail: no AlertBanner; show suggested price inline even when alert is active; show compact inline reason + Dismiss button\n- Dismiss now clears suggested_sell_price in DB (PATCH clearSuggestedSellPrice) and sets the same 10m ack key to avoid immediate re-alerts\n- Webhook alerts: suppress redundant re-push if trade already at suggested price or suggestion already stored\n\nFiles:\n- packages/web/src/components/trades/TradeDetail.tsx\n- packages/web/src/components/HomePage.tsx\n- packages/web/src/pages/api/trades/active/[id]/index.ts\n- packages/web/src/pages/api/webhooks/alerts.ts