### PR TITLE
[codex] Simplify trade fill flow and add overdue tooltip

### DIFF
--- a/packages/web/src/components/trades/TradeCard.tsx
+++ b/packages/web/src/components/trades/TradeCard.tsx
@@ -69,7 +69,7 @@ export function TradeCard(props: TradeCardProps) {
     switch (props.trade.status) {
       case 'check_in':
         return (
-          <Tooltip text="Tap to report how much of your GE offer has filled" position="bottom" delay={200}>
+          <Tooltip text="Tap to mark your order as filled or partially filled" position="bottom" delay={200}>
             <span class="status-badge status-check-in">Check-in</span>
           </Tooltip>
         );
@@ -97,7 +97,9 @@ export function TradeCard(props: TradeCardProps) {
           {(props.alert || props.trade.suggestedSellPrice) ? (
             <span class="status-badge status-alert">Price alert</span>
           ) : isOverdue() ? (
-            <span class="status-badge status-overdue">Overdue</span>
+            <Tooltip text="This trade has been open longer than the expected completion time." position="bottom" delay={200}>
+              <span class="status-badge status-overdue">Overdue</span>
+            </Tooltip>
           ) : (
             getStatusBadge()
           )}


### PR DESCRIPTION
## Summary
This change replaces the percentage-based order fill interaction in the trade detail UI with a discrete, action-oriented flow that better matches real user behavior. It also adds explanatory hover text for overdue trades.

Users now choose between "Order filled" and "Order partially filled" during the buy phase, and if they select partial fill they provide the bought quantity before the trade transitions to selling. In the sell phase, users mark the order as sold and are prompted to confirm whether they sold at the recommended price or at another price.

## Problem and User Impact
The previous slider-based fill percentage check-in asked users to estimate progress continuously, which was noisy and not tied cleanly to key actions they actually take in-game. That made the flow feel less useful and created friction around transitioning phases and recording outcomes.

Overdue status also lacked contextual explanation, so users could see a warning badge without understanding what condition triggered it.

## Root Cause
The UI and component contracts were built around a generic `progress` model (`0-100`), including `CheckInBar`, `TradeDetail`, and `TradeList`, rather than around discrete order-state transitions. This made the primary workflow dependent on slider input and check-in persistence rather than explicit buy/sell milestones.

## Fix
- Reworked `CheckInBar` to remove the range slider and replace it with:
  - `Order filled`
  - `Order partially filled` + quantity input (validated and capped by trade quantity)
  - `Order sold` in selling phase
- Updated `TradeDetail` to:
  - Use explicit callbacks for buy-phase advancement and sale completion
  - Show post-sale confirmation options:
    - Sold at recommended price
    - Sold at other price (manual sell price input)
- Updated `TradeList` wiring to use existing endpoints for the new flow:
  - Partial buy fill: `PATCH /api/trades/active/:id` (quantity) then `POST /advance`
  - Full buy fill: `POST /advance`
  - Sale completion: `POST /complete` with selected sell price
- Added tooltip copy for overdue badge in `TradeCard`:
  - "This trade has been open longer than the expected completion time."

## Validation
- Built web package successfully:
  - `npm run build:web`

This confirms the Solid/Astro UI changes compile and bundle correctly.
