### PR TITLE
Docs: documentation improvements

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -9,3 +9,25 @@ This repo is organized by deployment unit:
 - `packages/shared`: Shared TypeScript utilities/types used by web
 
 Server `systemd` units live in `infra/systemd/`.
+
+## Local Dev Quick Start
+
+From the repo root:
+
+```bash
+npm install
+
+# Frontend
+npm run dev:web
+
+# Engine API
+npm run dev:engine
+```
+
+Common workspace helpers:
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+```

--- a/packages/collectors/README.md
+++ b/packages/collectors/README.md
@@ -44,6 +44,7 @@ OSRS Wiki API → Docker Collectors → PostgreSQL/TimescaleDB → ML Pipeline
    EOF
    ```
    You can also start from `gept-export.env.example` and trim it down for local use. Keep `.env` gitignored.
+   Required envs: `DB_PASS` (others default to the values above). Optional: `USER_AGENT` to customize OSRS Wiki API requests.
 
 2. **Deploy with Docker Compose**:
    ```bash
@@ -57,7 +58,14 @@ OSRS Wiki API → Docker Collectors → PostgreSQL/TimescaleDB → ML Pipeline
    curl http://localhost:9100/metrics  # Prometheus metrics
    ```
 
-**Note:** `docker-compose.yml` uses `network_mode: host`, so the ports above are exposed directly on the host.
+**Note:** `docker-compose.yml` uses `network_mode: host`, so the ports above are exposed directly on the host. Host networking is Linux-only; on macOS/Windows, use a Linux VM or adjust the compose file to publish ports.
+
+### Run a Single Collector Locally
+
+```bash
+source .env
+python collect_5m_pg.py
+```
 
 ### Monitoring
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -55,6 +55,12 @@ pip install -r requirements.txt
 
 ### Environment Setup
 
+Start from the templates:
+
+```bash
+cp .env.example .env
+```
+
 Create a local `.env` in `packages/engine` (loaded by `src/main.py`) with the minimum required values:
 
 ```bash
@@ -105,6 +111,9 @@ cp .env.docker.example .env.docker
 docker compose -f docker-compose.local.yml --env-file .env.docker up --build
 ```
 
+Optional: set `REDIS_URL=redis://redis:6379/0` in `.env.docker` to enable caching
+using the bundled Redis container.
+
 Then open `http://localhost:8000/docs` or hit `http://localhost:8000/healthz`.
 
 ### Verify Connection
@@ -122,6 +131,8 @@ curl http://localhost:8000/api/v1/health
 | `/api/v1/recommendations/item/{item_id}` | GET | Lookup by item ID |
 | `/api/v1/predictions/{item_id}` | GET | Get all predictions for an item |
 | `/api/v1/health` | GET | Health check |
+
+Full request/response shapes live in `docs/API.md` and `docs/openapi.json`.
 
 ### Get Recommendations
 

--- a/packages/engine/docs/API.md
+++ b/packages/engine/docs/API.md
@@ -110,9 +110,33 @@ curl -X POST "http://localhost:8000/api/v1/recommendations" \
 | `style` | string | No | `passive`, `hybrid`, `active` (default: `hybrid`) |
 | `capital` | integer | **Yes** | Available GP (minimum: 1000) |
 | `risk` | string | No | `low`, `medium`, `high` (default: `medium`) |
-| `slots` | integer | No | Available GE slots, 1-8 (default: 4) |
+| `slots` | integer | No | Available GE slots, 1-20 (default: 4) |
+| `user_tier` | string | No | `free`, `premium`, `unlimited` (default: `free`) |
 | `activeTrades` | array | No | Currently tracked trades (auto-excluded) |
 | `userId` | string | No | Hashed user ID for crowding tracking |
+| `offset_pct` | number | No | Target offset percentage (0.0125 to 0.0250) |
+| `min_offset_pct` | number | No | Minimum offset percentage (0.0125 to 0.0250) |
+| `max_offset_pct` | number | No | Maximum offset percentage (0.0125 to 0.0250) |
+| `include_metadata` | boolean | No | Include freshness metadata in response |
+| `return_all` | boolean | No | Return all viable flips instead of slot-limited portfolio |
+
+**Slot limits:** when `return_all=false`, the API enforces max `slots=8` for `free`/`premium` and max `slots=20` for `unlimited`.
+
+**Example (metadata):**
+```bash
+curl -X POST "http://localhost:8000/api/v1/recommendations" \
+  -H "X-API-Key: $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"style":"hybrid","capital":5000000,"include_metadata":true}'
+```
+
+**Example (return all):**
+```bash
+curl -X POST "http://localhost:8000/api/v1/recommendations" \
+  -H "X-API-Key: $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"style":"active","capital":15000000,"return_all":true}'
+```
 
 #### GET (Alternative)
 
@@ -133,10 +157,15 @@ curl -H "X-API-Key: $INTERNAL_API_KEY" \
 | `style` | string | No | `passive`, `hybrid`, `active` (default: `hybrid`) |
 | `capital` | integer | **Yes** | Available GP (minimum: 1000) |
 | `risk` | string | No | `low`, `medium`, `high` (default: `medium`) |
-| `slots` | integer | No | Available GE slots, 1-8 (default: 4) |
+| `slots` | integer | No | Available GE slots, 1-20 (default: 4) |
+| `user_tier` | string | No | `free`, `premium`, `unlimited` (default: `free`) |
 | `exclude` | string | No | Comma-separated recommendation IDs to exclude |
 | `exclude_item_ids` | string | No | Comma-separated item IDs to exclude (e.g., `536,5295,4151`) |
 | `user_id` | string | No | Hashed user ID for crowding tracking |
+| `offset_pct` | number | No | Target offset percentage (0.0125 to 0.0250) |
+| `min_offset_pct` | number | No | Minimum offset percentage (0.0125 to 0.0250) |
+| `max_offset_pct` | number | No | Maximum offset percentage (0.0125 to 0.0250) |
+| `max_hour_offset` | integer | No | Override time horizon in hours (1-24) |
 
 **Response:**
 ```json

--- a/packages/engine/docs/DISCORD_BOT_INTEGRATION.md
+++ b/packages/engine/docs/DISCORD_BOT_INTEGRATION.md
@@ -11,6 +11,7 @@ This document tracks integration details and coordination between the Discord bo
 | Endpoint | Bot Usage | Status |
 |----------|-----------|--------|
 | `GET /api/v1/recommendations` | Main flip command | ✅ Active |
+| `POST /api/v1/recommendations` | Rich flip command (tier + metadata) | ✅ Active |
 | `GET /api/v1/recommendations/item/{id}` | Item lookup | ✅ Active |
 | `GET /api/v1/items/search` | Autocomplete for `/report`, `/item` | ✅ Active |
 | `POST /api/v1/recommendations/{rec_id}/outcome` | Trade outcome reporting | ✅ Active |
@@ -63,6 +64,15 @@ GET /api/v1/recommendations?capital=10000000&user_id=sha256_hash&exclude=rec_123
 **Status:**
 - [x] `exclude_item_ids` implemented (PR #33)
 - [x] Crowding tracker active
+
+### 4. Recommendation Tiers + Metadata
+
+For paid tiers, prefer the POST endpoint so we can send `user_tier` and request
+`include_metadata` or `return_all` for experimentation.
+
+```
+POST /api/v1/recommendations
+```
 
 ---
 

--- a/packages/engine/docs/feedback.md
+++ b/packages/engine/docs/feedback.md
@@ -49,6 +49,7 @@ X-API-Key: <token>
   "itemName": "Dragon bones",
   "feedbackType": "price_too_high",
   "recId": "rec_536_2026011510",
+  "offsetPct": 0.018,
   "side": "buy",
   "notes": "Price jumped 10% right after recommendation",
   "recommendedPrice": 2000,
@@ -66,11 +67,20 @@ X-API-Key: <token>
 | `itemName` | string | Yes | Item name |
 | `feedbackType` | string | Yes | One of the feedback types above |
 | `recId` | string | No | Recommendation ID to link feedback |
+| `offsetPct` | number | No | Offset percentage associated with the recommendation |
 | `side` | string | No | `buy` or `sell` |
 | `notes` | string | No | Free-text notes (max 500 chars) |
 | `recommendedPrice` | integer | No | Price from recommendation |
 | `actualPrice` | integer | No | Actual price user encountered |
 | `submittedAt` | string | Yes | ISO 8601 timestamp |
+
+`recId`, when provided, must match `rec_{item_id}_{YYYYMMDDHH}`.
+
+To hash a user ID quickly:
+
+```bash
+python - <<'PY'\nimport hashlib\nprint(hashlib.sha256(b\"123456789012345678\").hexdigest())\nPY
+```
 
 ### Response
 
@@ -87,6 +97,8 @@ X-API-Key: <token>
 ```
 GET /api/v1/feedback/analytics?period=week
 ```
+
+Requires the same `X-API-Key` header as the write endpoint.
 
 ### Query Parameters
 

--- a/packages/engine/docs/trade-outcomes.md
+++ b/packages/engine/docs/trade-outcomes.md
@@ -64,6 +64,10 @@ X-API-Key: <token>
 | `actualProfit` | integer | Yes | Actual profit/loss after GE tax (can be negative) |
 | `reportedAt` | string | Yes | ISO 8601 timestamp when user reported outcome |
 
+`recId` must follow `rec_{item_id}_{YYYYMMDDHH}`.
+
+Use the tax rules in `docs/TAX_RULES.md` when computing `actualProfit`.
+
 ## Response Format
 
 ### Success Response (200 OK)

--- a/packages/engine/migrations/README.md
+++ b/packages/engine/migrations/README.md
@@ -38,6 +38,15 @@ Apply migrations in numeric order:
 ls -1 migrations/*.sql | sort
 ```
 
+### Verify Applied
+
+After running a migration, verify the table exists:
+
+```bash
+psql "$DB_CONNECTION_STRING" -c "\\dt"
+psql "$DB_CONNECTION_STRING" -c "\\d trade_outcomes"
+```
+
 ## Migration Files
 
 - `001_create_trade_outcomes_table.sql` - Creates the `trade_outcomes` table for storing user-reported trade results

--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -16,10 +16,17 @@ python src/pipeline/run_patchtst_inference.py --model-path /path/to/best_model.p
 ```
 
 The production job runs as a `systemd` timer that launches a one-shot Docker container (see `infra/systemd/gept-inference.*`).
+For cron-style runs outside Docker, use `run_inference.py` as the entry point.
 
 ## Local Setup
 
 For full environment setup (database tunnel, env vars, dependencies), see `DEVELOPER_SETUP.md`.
+If you already have a local `.env`, load it before running inference:
+
+```bash
+source .env
+python run_inference.py
+```
 
 ## Deployment
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -49,12 +49,15 @@ BETTER_AUTH_URL=http://localhost:4321
 
 If auth runs on a separate local server, keep `BETTER_AUTH_URL` pointed at that server instead.
 
+`ENGINE_WEBHOOK_URL` defaults to `http://localhost:8000/webhooks/trades` if unset. Set `WEBHOOK_SECRET` (min 32 chars) to enable outbound webhooks and the `/api/trades/resync` endpoint.
+
 ## Scripts
 
 ```bash
 npm run dev:web      # local dev server
 npm run build:web    # production build
 npm run preview --workspace=@gept/web
+npm run test --workspace=@gept/web  # build + middleware/auth checks
 ```
 
 `npm run preview --workspace=@gept/web` requires a prior `npm run build:web`.


### PR DESCRIPTION
## Summary
- Added a monorepo quick-start with common scripts.
- Documented engine env templates, optional Redis caching, and API doc locations.
- Expanded API docs with user tiers, offset filters, metadata/return_all options, and examples.
- Added feedback docs for offsetPct, recId format, hashing helper, and analytics auth.
- Clarified trade outcome recId format and tax rule reference for net profit.
- Added migration verification commands.
- Documented collectors required envs, host-networking note, and single-script run.
- Clarified web webhook defaults/secret requirement and added test command.
- Added inference run_inference entrypoint and .env usage.
- Noted POST recommendations for bot tier/metadata usage.

## Files Modified
- packages/README.md
- packages/collectors/README.md
- packages/engine/README.md
- packages/engine/docs/API.md
- packages/engine/docs/DISCORD_BOT_INTEGRATION.md
- packages/engine/docs/feedback.md
- packages/engine/docs/trade-outcomes.md
- packages/engine/migrations/README.md
- packages/inference/README.md
- packages/web/README.md
