### PR TITLE
Docs: documentation improvements

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -9,3 +9,21 @@ This repo is organized by deployment unit:
 - `packages/shared`: Shared TypeScript utilities/types used by web
 
 Server `systemd` units live in `infra/systemd/`.
+
+## Common Monorepo Commands
+
+Run from repo root:
+
+```bash
+npm install
+npm run dev:web
+npm run dev:engine
+```
+
+Other helpful scripts:
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+```

--- a/packages/collectors/README.md
+++ b/packages/collectors/README.md
@@ -47,7 +47,7 @@ OSRS Wiki API → Docker Collectors → PostgreSQL/TimescaleDB → ML Pipeline
 
 2. **Deploy with Docker Compose**:
    ```bash
-   docker-compose up -d
+   docker compose --env-file .env up -d
    ```
 
 3. **Verify Services**:
@@ -58,6 +58,18 @@ OSRS Wiki API → Docker Collectors → PostgreSQL/TimescaleDB → ML Pipeline
    ```
 
 **Note:** `docker-compose.yml` uses `network_mode: host`, so the ports above are exposed directly on the host.
+
+To run a single collector during development:
+
+```bash
+docker compose --env-file .env up ge-5m-collector
+```
+
+To stop everything:
+
+```bash
+docker compose down
+```
 
 ### Monitoring
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -55,7 +55,13 @@ pip install -r requirements.txt
 
 ### Environment Setup
 
-Create a local `.env` in `packages/engine` (loaded by `src/main.py`) with the minimum required values:
+Start from the template:
+
+```bash
+cp .env.example .env
+```
+
+Then edit the local `.env` in `packages/engine` (loaded by `src/main.py`) with the minimum required values:
 
 ```bash
 # Database (via SSH tunnel)
@@ -94,6 +100,12 @@ uvicorn src.api:app --host 0.0.0.0 --port 8000 --reload
 
 # Or use the main entry point
 python -m src.main
+```
+
+### Tests
+
+```bash
+pytest
 ```
 
 ### Running (Docker)

--- a/packages/engine/migrations/README.md
+++ b/packages/engine/migrations/README.md
@@ -38,6 +38,15 @@ Apply migrations in numeric order:
 ls -1 migrations/*.sql | sort
 ```
 
+### Verify Applied
+
+After running a migration, confirm the table exists and is queryable:
+
+```bash
+psql -v ON_ERROR_STOP=1 "$DB_CONNECTION_STRING" -c "\\dt trade_outcomes"
+psql -v ON_ERROR_STOP=1 "$DB_CONNECTION_STRING" -c "SELECT COUNT(*) FROM trade_outcomes;"
+```
+
 ## Migration Files
 
 - `001_create_trade_outcomes_table.sql` - Creates the `trade_outcomes` table for storing user-reported trade results

--- a/packages/inference/DEVELOPER_SETUP.md
+++ b/packages/inference/DEVELOPER_SETUP.md
@@ -4,8 +4,9 @@
 
 ### 1. Clone the Repository
 ```bash
-git clone https://github.com/MarcusFranz/gept-foundations.git
-cd gept-foundations
+git clone https://github.com/MarcusFranz/gept.git
+cd gept
+cd packages/inference
 ```
 
 ### 2. Set Up Environment Variables

--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -10,8 +10,11 @@ PatchTST-based inference job for the GePT Grand Exchange prediction system.
 ## Running Inference
 
 ```bash
+python -m venv venv
+source venv/bin/activate
+cp .env.example .env
+source .env
 pip install -r requirements.txt
-export DB_PASS=replace-with-secure-password
 python src/pipeline/run_patchtst_inference.py --model-path /path/to/best_model.pt
 ```
 

--- a/packages/inference/RECOMMENDATION_ENGINE.md
+++ b/packages/inference/RECOMMENDATION_ENGINE.md
@@ -103,6 +103,8 @@ CREATE TABLE predictions (
 
 ## Querying Predictions
 
+If the `latest_predictions` or `top_opportunities` views are not available in your database, use the explicit queries shown below instead.
+
 ### Get Latest Predictions (Most Recent Batch)
 
 ```sql

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -37,6 +37,14 @@ Optional:
 - `PREDICTION_API` and `PREDICTION_API_KEY` for live recommendations
 - `ENGINE_WEBHOOK_URL` and `WEBHOOK_SECRET` for active-trade alerts
 
+### Generate Local Secrets
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+Use the output for `BETTER_AUTH_SECRET` (and `WEBHOOK_SECRET` if you're testing alerts).
+
 ### Local URLs
 
 If you run everything on the Astro dev server, align these values to the dev port:
@@ -58,6 +66,7 @@ npm run preview --workspace=@gept/web
 ```
 
 `npm run preview --workspace=@gept/web` requires a prior `npm run build:web`.
+For a local preview on the same port, pass `-- --port 4321` and keep `PUBLIC_APP_URL`/`SITE` in sync.
 
 ## Production Notes
 


### PR DESCRIPTION
## Summary
- Added monorepo command quickstart in packages overview.
- Documented copying `.env.example` for engine local setup.
- Added engine test command (`pytest`).
- Added migration verification commands after apply.
- Added local secret generation helper for web env.
- Noted preview port alignment for web preview runs.
- Updated inference setup clone path and explicit `packages/inference` step.
- Added venv + `.env` usage steps for inference runs.
- Noted fallback to explicit queries if prediction views are missing.
- Documented compose env-file usage, single-service run, and shutdown commands for collectors.

## Files Modified
- packages/README.md
- packages/collectors/README.md
- packages/engine/README.md
- packages/engine/migrations/README.md
- packages/inference/DEVELOPER_SETUP.md
- packages/inference/README.md
- packages/inference/RECOMMENDATION_ENGINE.md
- packages/web/README.md